### PR TITLE
Prevent Desert Surface 7 and Light 3 skips

### DIFF
--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -59,13 +59,15 @@ void Randomizer::RandomizeDesert() {
 	std::vector<int> puzzles = desertPanels;
 	std::vector<int> valid1 = { 0x00698, 0x0048F, 0x09F92, 0x09DA6, 0x0078D, 0x04D18, 0x0117A, 0x17ECA, 0x0A02D };
 	std::vector<int> valid2 = { 0x00698, 0x09F92, 0x0A036, 0x0A049, 0x0A053, 0x00422, 0x006E3, 0x00C72, 0x008BB, 0x0078D, 0x01205, 0x181AB, 0x012D7, 0x17ECA, 0x0A02D };
-	std::vector<int> valid3 = { 0x00698, 0x0048F, 0x09F92, 0x0A036, 0x0A049, 0x00422, 0x008BB, 0x0078D, 0x18313, 0x01205, 0x012D7 };
+	std::vector<int> valid3 = { 0x00698, 0x0048F, 0x09F92, 0x0A036, 0x0A049, 0x00422, 0x008BB, 0x0078D, 0x18313, 0x01205 };
+	std::vector<int> validSurfaceSeven = { 0x00698, 0x0048F, 0x09F92, 0x0A036, 0x0A049, 0x0A053, 0x00422, 0x006E3, 0x0A02D, 0x00C72, 0x0129D, 0x008BB, 0x0078D, 0x18313, 0x04D18, 0x01205, 0x181AB, 0x17ECA, 0x012D7 };
 	int endIndex = static_cast<int>(desertPanels.size());
 	for (int i = 0; i < endIndex - 1; i++) {
 		const int target = Random::rand() % (endIndex - i) + i;
-		//Prevent ambiguity caused by shadows
+		//Prevent ambiguity caused by shadows, and ensure all latches on Surface 7 and Light 3 must be opened
 		if (i == target || i == 1 && std::find(valid1.begin(), valid1.end(), desertPanels[target]) == valid1.end() || 
 			(i == 2 || i == 9) && std::find(valid2.begin(), valid2.end(), desertPanels[target]) == valid2.end() ||
+			i == 6 && std::find(validSurfaceSeven.begin(), validSurfaceSeven.end(), desertPanels[target]) == validSurfaceSeven.end() ||
 			i == 10 && std::find(valid3.begin(), valid3.end(), desertPanels[target]) == valid3.end()) {
 			i--;
 			continue;


### PR DESCRIPTION
If Desert Surface 7 is swapped with Surface 5, Surface 8, or Flood 4, you are not required to open all three latches to solve the panel. Similarly, if Light 3 is swapped with Final Far, you only have to open one of the two latches. The improbability of such swaps happening makes it infeasible to run Low%, because you would have to reset until you found an admissible seed. This patch prevents those specific swaps from happening so that players are always required to solve all surface panels and both light room panels.

(I'm not sure if you're accepting pull requests on this project, but if you are, I hope this is helpful!)