### PR TITLE
Make Desert re-randomisation consistent with original invocation

### DIFF
--- a/Source/Panel.cpp
+++ b/Source/Panel.cpp
@@ -293,6 +293,7 @@ bool Panel::LoadPanels(int seed, bool hard)
 	}
 	Random::seed(seed);
 	//Random::SetSeed(seed);
+	Random::rand(); // Ignore value; this is done so that the RNG matches the state that Desert was initially generated in
 	Randomizer().RandomizeDesert();
 	file >> size;
 	while (size-- > 0) {

--- a/Source/PuzzleList.cpp
+++ b/Source/PuzzleList.cpp
@@ -9,6 +9,7 @@ void PuzzleList::GenerateAllN()
 {
 	generator->setLoadingData(336);
 	CopyTargets();
+	GenerateDesertN();
 	GenerateTutorialN();
 	GenerateSymmetryN();
 	GenerateQuarryN();
@@ -19,7 +20,6 @@ void PuzzleList::GenerateAllN()
 	GenerateVaultsN();
 	GenerateTrianglePanelsN();
 	GenerateOrchardN();
-	GenerateDesertN();
 	GenerateKeepN();
 	GenerateJungleN();
 	GenerateMountainN();
@@ -34,6 +34,7 @@ void PuzzleList::GenerateAllH()
 {
 	generator->setLoadingData(349);
 	CopyTargets();
+	GenerateDesertH();
 	GenerateTutorialH();
 	GenerateSymmetryH();
 	GenerateQuarryH();
@@ -44,7 +45,6 @@ void PuzzleList::GenerateAllH()
 	GenerateVaultsH();
 	GenerateTrianglePanelsH();
 	GenerateOrchardH();
-	GenerateDesertH();
 	GenerateKeepH();
 	GenerateJungleH();
 	GenerateMountainH();


### PR DESCRIPTION
Currently, if you randomise a file, quit the game, reopen, and then re-randomise the file, the Desert panels do not match how they were shuffled initially. This is because Desert is shuffled rather late in the original invocation, but is the only thing that RNG is actually used for when re-randomising, so the RNG is not in the same state in both cases. This change re-orders the initial invocation such that Desert is shuffled before anything else.