### PR TITLE
Double randomizer mode

### DIFF
--- a/App/Main.cpp
+++ b/App/Main.cpp
@@ -243,6 +243,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 			SetWindowText(hwndRandomize, L"Randomizing...");
 			randomizer->seed = seed;
 			randomizer->colorblind = IsDlgButtonChecked(hwnd, IDC_COLORBLIND);
+			randomizer->doubleMode = doubleMode;
 			if (hard) randomizer->GenerateHard(hwndLoadingText);
 			else randomizer->GenerateNormal(hwndLoadingText);
 			Special::WritePanelData(0x00064, BACKGROUND_REGION_COLOR + 12, seed);

--- a/App/Main.cpp
+++ b/App/Main.cpp
@@ -40,6 +40,7 @@
 #define IDC_DIFFICULTY_NORMAL 0x501
 #define IDC_DIFFICULTY_EXPERT 0x502
 #define IDC_COLORBLIND 0x503
+#define IDC_DOUBLE 0x504
 
 #define SHAPE_11 0x1000
 #define SHAPE_12 0x2000
@@ -72,7 +73,7 @@
 //Panel to edit
 int panel = 0x09E69;
 
-HWND hwndSeed, hwndRandomize, hwndCol, hwndRow, hwndElem, hwndColor, hwndLoadingText, hwndNormal, hwndExpert, hwndColorblind;
+HWND hwndSeed, hwndRandomize, hwndCol, hwndRow, hwndElem, hwndColor, hwndLoadingText, hwndNormal, hwndExpert, hwndColorblind, hwndDoubleMode;
 std::shared_ptr<Panel> _panel;
 std::shared_ptr<Randomizer> randomizer = std::make_shared<Randomizer>();
 std::shared_ptr<Generate> generator = std::make_shared<Generate>();
@@ -209,7 +210,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 				else break;
 			}
 			
-			ShowWindow(hwndColorblind, SW_HIDE);
+			EnableWindow(hwndColorblind, false);
+			EnableWindow(hwndDoubleMode, false);
 			if (colorblind) {
 				std::ofstream out("WRPGconfig.txt");
 				out << "colorblind:true" << std::endl;
@@ -386,7 +388,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
 	RegisterClassW(&wndClass);
 
 	HWND hwnd = CreateWindow(WINDOW_CLASS, PRODUCT_NAME, WS_OVERLAPPEDWINDOW,
-      650, 200, 600, DEBUG ? 700 : 200, nullptr, nullptr, hInstance, nullptr);
+      650, 200, 600, DEBUG ? 700 : 320, nullptr, nullptr, hInstance, nullptr);
 
 	//Initialize memory globals constant depending on game version
 	Memory memory("witness64_d3d11.exe");
@@ -447,25 +449,31 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
 	if (hard) SendMessage(hwndExpert, BM_SETCHECK, BST_CHECKED, 1);
 	else SendMessage(hwndNormal, BM_SETCHECK, BST_CHECKED, 1);
 
+	CreateWindow(L"STATIC", L"Options:",
+		WS_TABSTOP | WS_VISIBLE | WS_CHILD | SS_LEFT,
+		10, 125, 120, 16, hwnd, NULL, hInstance, NULL);
+	hwndColorblind = CreateWindow(L"BUTTON", L"Colorblind Mode - The colors on certain panels will be changed to be more accommodating to people with colorblindness. The puzzles themselves are identical to those generated without colorblind mode enabled.",
+		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_CHECKBOX | BS_MULTILINE,
+		10, 145, 570, 50, hwnd, (HMENU)IDC_COLORBLIND, hInstance, NULL);
+	hwndDoubleMode = CreateWindow(L"BUTTON", L"Double Mode - In addition to generating new puzzles, the randomizer will also shuffle the location of most puzzles.",
+		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_CHECKBOX | BS_MULTILINE,
+		10, 200, 570, 35, hwnd, (HMENU)IDC_DOUBLE, hInstance, NULL);
+
 	CreateWindow(L"STATIC", L"Enter a seed (optional):",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | SS_LEFT,
-		10, 125, 160, 16, hwnd, NULL, hInstance, NULL);
+		10, 250, 160, 16, hwnd, NULL, hInstance, NULL);
 	hwndSeed = CreateWindow(MSFTEDIT_CLASS, lastSeed == 0 ? L"" : std::to_wstring(lastSeed).c_str(),
         WS_TABSTOP | WS_VISIBLE | WS_CHILD | WS_BORDER,
-        180, 120, 60, 26, hwnd, NULL, hInstance, NULL);
+        180, 245, 60, 26, hwnd, NULL, hInstance, NULL);
 	SendMessage(hwndSeed, EM_SETEVENTMASK, NULL, ENM_CHANGE); // Notify on text change
 
 	hwndRandomize = CreateWindow(L"BUTTON", L"Randomize",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
-		250, 120, 130, 26, hwnd, (HMENU)IDC_RANDOMIZE, hInstance, NULL);
+		250, 245, 130, 26, hwnd, (HMENU)IDC_RANDOMIZE, hInstance, NULL);
 
 	hwndLoadingText = CreateWindow(L"STATIC", L"",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | SS_LEFT,
-		400, 125, 160, 16, hwnd, NULL, hInstance, NULL);
-
-	hwndColorblind = CreateWindow(L"BUTTON", L"Colorblind mode",
-		WS_VISIBLE | WS_CHILD | BS_CHECKBOX,
-		400, 125, 130, 16, hwnd, (HMENU)IDC_COLORBLIND, hInstance, NULL);
+		400, 250, 160, 16, hwnd, NULL, hInstance, NULL);
 
 	std::ifstream configFile("WRPGconfig.txt");
 	if (configFile.is_open()) {

--- a/Source/Panel.cpp
+++ b/Source/Panel.cpp
@@ -12,6 +12,7 @@
 
 int Point::pillarWidth = 0;
 std::vector<Panel> Panel::generatedPanels;
+std::vector<std::tuple<int, int>> Panel::arrowPuzzles;
 
 template <class T>
 int find(const std::vector<T> &data, T search, size_t startIndex = 0) {
@@ -331,8 +332,20 @@ void Panel::WriteDecorations() {
 		_memory->WriteArray<int>(id, DECORATION_FLAGS, decorations);
 	}
 	if (arrows) {
-		ArrowWatchdog* watchdog = new ArrowWatchdog(id, Point::pillarWidth);
-		watchdog->style = _style;
+		arrowPuzzles.emplace_back(id, Point::pillarWidth);
+	}
+}
+
+void Panel::StartArrowWatchdogs(const std::map<int, int>& shuffleMappings) {
+	std::map<int, int> invertedMappings;
+	for (const auto& [from, to] : shuffleMappings) {
+		invertedMappings[to] = from;
+	}
+	for (const auto& [id, pillarWidth] : arrowPuzzles) {
+		int realId = id;
+		if (invertedMappings.count(realId)) realId = invertedMappings.at(realId);
+
+		ArrowWatchdog* watchdog = new ArrowWatchdog(realId, pillarWidth);
 		watchdog->start();
 	}
 }

--- a/Source/Panel.h
+++ b/Source/Panel.h
@@ -2,6 +2,7 @@
 #include "Memory.h"
 #include "Randomizer.h"
 #include <stdint.h>
+#include <tuple>
 
 struct Point {
 	int first;
@@ -147,6 +148,8 @@ public:
 	void SetGridSymbol(int x, int y, Decoration::Shape symbol, Decoration::Color color);
 	void ClearGridSymbol(int x, int y);
 	void Resize(int width, int height);
+
+	static void StartArrowWatchdogs(const std::map<int, int>& shuffleMappings = {});
 
 	enum Style {
 		SYMMETRICAL = 0x2, //Not on the town symmetry puzzles? IDK why.
@@ -432,6 +435,7 @@ private:
 	int id;
 
 	static std::vector<Panel> generatedPanels;
+	static std::vector<std::tuple<int, int>> arrowPuzzles;
 
 	friend class PanelExtractionTests;
 	friend class Generate;

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -670,6 +670,103 @@ std::vector<int> squarePanels = {
     0x09E85, // Tunnels Town Shortcut
 };
 
+std::vector<int> arrowPanels = {
+    0x17CFB, // Outside Tutorial Discard
+    0x3C12B, // Glass Factory Discard
+    0x17CE7, // Desert Discard
+    0x17CF0, // Mill Discard
+    0x17FA9, // Treehouse Green Bridge Discard
+    0x17FA0, // Treehouse Laser Discard
+    0x17D27, // Keep Discard
+    0x17D28, // Shipwreck Discard
+    0x17D01, // Town Orange Crate Discard
+    0x17C71, // Town Rooftop Discard
+    0x17CF7, // Theater Discard
+    0x17F9B, // Jungle Discard
+    0x17F93, // Mountain 2 Discard
+    0x17FA2, // Mountain 3 Secret Door
+    0x17C42, // Mountainside Discard
+    0x00FF8, // UTM Entrance Door
+    0x0A16B, // UTM Green Dots 1
+    0x0A2CE, // UTM Green Dots 2
+    0x0A2D7, // UTM Green Dots 3
+    0x0A2DD, // UTM Green Dots 4
+    0x0A2EA, // UTM Green Dots 5
+    0x17FB9, // UTM Green Dots 6
+    0x0008F, // UTM Invisible Dots 1
+    0x0006B, // UTM Invisible Dots 2
+    0x0008B, // UTM Invisible Dots 3
+    0x0008C, // UTM Invisible Dots 4
+    0x0008A, // UTM Invisible Dots 5
+    0x00089, // UTM Invisible Dots 6
+    0x0006A, // UTM Invisible Dots 7
+    0x0006C, // UTM Invisible Dots 8
+    0x00027, // UTM Invisible Dots Symmetry 1
+    0x00028, // UTM Invisible Dots Symmetry 2
+    0x00029, // UTM Invisible Dots Symmetry 3
+    0x021D7, // UTM Mountainside Shortcut
+    0x00B71, // UTM Quarry
+    0x01A31, // UTM Rainbow
+    0x32962, // UTM Swamp
+    0x32966, // UTM Treehouse
+    0x17CF2, // UTM Waterfall Shortcut
+    0x00A72, // UTM Blue Cave In
+    0x009A4, // UTM Blue Discontinuous
+    0x018A0, // UTM Blue Easy Symmetry
+    0x01A0D, // UTM Blue Hard Symmetry
+    0x008B8, // UTM Blue Left 1
+    0x00973, // UTM Blue Left 2
+    0x0097B, // UTM Blue Left 3
+    0x0097D, // UTM Blue Left 4
+    0x0097E, // UTM Blue Left 5
+    0x00994, // UTM Blue Right Far 1
+    0x334D5, // UTM Blue Right Far 2
+    0x00995, // UTM Blue Right Far 3
+    0x00996, // UTM Blue Right Far 4
+    0x00998, // UTM Blue Right Far 5
+    0x00190, // UTM Blue Right Near 1
+    0x00558, // UTM Blue Right Near 2
+    0x00567, // UTM Blue Right Near 3
+    0x006FE, // UTM Blue Right Near 4
+    0x0A16E, // UTM Challenge Entrance
+    0x039B4, // Tunnels Theater Catwalk
+    0x09E85, // Tunnels Town Shortcut
+};
+
+std::vector<int> glassPanels = {
+    0x01A54, // Glass Factory Entry
+    0x00086, // Glass Factory Vertical Symmetry 1
+    0x00087, // Glass Factory Vertical Symmetry 2
+    0x00059, // Glass Factory Vertical Symmetry 3
+    0x00062, // Glass Factory Vertical Symmetry 4
+    0x0008D, // Glass Factory Rotational Symmetry 1
+    0x00081, // Glass Factory Rotational Symmetry 2
+    0x00083, // Glass Factory Rotational Symmetry 3
+    0x00084, // Glass Factory Melting 1
+    0x00082, // Glass Factory Melting 2
+    0x0343A, // Glass Factory Melting 3
+    0x000B0, // Symmetry Island Door 1
+    0x00022, // Symmetry Island Black Dots 1
+    0x00023, // Symmetry Island Black Dots 2
+    0x00024, // Symmetry Island Black Dots 3
+    0x00025, // Symmetry Island Black Dots 4
+    0x00026, // Symmetry Island Black Dots 5
+    0x0007C, // Symmetry Island Colored Dots 1
+    0x0007E, // Symmetry Island Colored Dots 2
+    0x00075, // Symmetry Island Colored Dots 3
+    0x00073, // Symmetry Island Colored Dots 4
+    0x00077, // Symmetry Island Colored Dots 5
+    0x00079, // Symmetry Island Colored Dots 6
+    0x00065, // Symmetry Island Fading Lines 1
+    0x0006D, // Symmetry Island Fading Lines 2
+    0x00072, // Symmetry Island Fading Lines 3
+    0x0006F, // Symmetry Island Fading Lines 4
+    0x00070, // Symmetry Island Fading Lines 5
+    0x00071, // Symmetry Island Fading Lines 6
+    0x00076, // Symmetry Island Fading Lines 7
+    0x28998, // Town Green Door
+};
+
 std::vector<int> squarePanelsExpertBanned = {
     0x09E7A, // Mountain 1 Green 1
     0x09E71, // Mountain 1 Green 2

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -56,6 +56,227 @@ std::vector<int> tutorialBackLeftOptions = {
 	0x0A3B5, // Tutorial Back Left
 };
 
+std::vector<int> tutorialBackLeftExpertOptions = {
+    0x0A3B2, // Tutorial Back Right
+    0x0A171, // Tutorial Optional Door 1
+    0x04CA4, // Tutorial Optional Door 2
+    0x17CFB, // Outside Tutorial Discard
+    0x3C12B, // Glass Factory Discard
+    0x01A54, // Glass Factory Entry
+    0x000B0, // Symmetry Island Door 1
+    0x17CE7, // Desert Discard
+    0x0CC7B, // Desert Vault
+    0x01E59, // Mill Entry Door Right
+    0x00E0C, // Mill Lower Row 1
+    0x01489, // Mill Lower Row 2
+    0x0148A, // Mill Lower Row 3
+    0x014D9, // Mill Lower Row 4
+    0x014E7, // Mill Lower Row 5
+    0x014E8, // Mill Lower Row 6
+    0x00557, // Mill Upper Row 1
+    0x005F1, // Mill Upper Row 2
+    0x00620, // Mill Upper Row 3
+    0x009F5, // Mill Upper Row 4
+    0x0146C, // Mill Upper Row 5
+    0x3C12D, // Mill Upper Row 6
+    0x03686, // Mill Upper Row 7
+    0x014E9, // Mill Upper Row 8
+    0x0367C, // Mill Control Room 1
+    0x17CF0, // Mill Discard
+    0x021D5, // Boathouse Ramp Activation Shapers
+    0x021B3, // Boathouse Erasers and Shapers 1
+    0x021B4, // Boathouse Erasers and Shapers 2
+    0x021B0, // Boathouse Erasers and Shapers 3
+    0x021AF, // Boathouse Erasers and Shapers 4
+    0x021AE, // Boathouse Erasers and Shapers 5
+    0x021B5, // Boathouse Erasers and Stars 1
+    0x021B6, // Boathouse Erasers and Stars 2
+    0x021B7, // Boathouse Erasers and Stars 3
+    0x021BB, // Boathouse Erasers and Stars 4
+    0x09DB5, // Boathouse Erasers and Stars 5
+    0x09DB1, // Boathouse Erasers and Stars 6
+    0x3C124, // Boathouse Erasers and Stars 7
+    0x09DB3, // Boathouse Erasers Shapers and Stars 1
+    0x09DB4, // Boathouse Erasers Shapers and Stars 2
+    0x0A3CB, // Boathouse Erasers Shapers and Stars 3
+    0x0A3CC, // Boathouse Erasers Shapers and Stars 4
+    0x0A3D0, // Boathouse Erasers Shapers and Stars 5
+    0x09E57, // Quarry Entry Gate 1
+    0x17C09, // Quarry Entry Gate 2
+    0x0288C, // Treehouse Door 1
+    0x02886, // Treehouse Door 2
+    0x17D72, // Treehouse Yellow 1
+    0x17D8F, // Treehouse Yellow 2
+    0x17D74, // Treehouse Yellow 3
+    0x17DAC, // Treehouse Yellow 4
+    0x17D9E, // Treehouse Yellow 5
+    0x17DB9, // Treehouse Yellow 6
+    0x17D9C, // Treehouse Yellow 7
+    0x17DC2, // Treehouse Yellow 8
+    0x17DC4, // Treehouse Yellow 9
+    0x0A182, // Treehouse Door 3
+    0x17DC8, // Treehouse First Purple 1
+    0x17DC7, // Treehouse First Purple 2
+    0x17CE4, // Treehouse First Purple 3
+    0x17D2D, // Treehouse First Purple 4
+    0x17D6C, // Treehouse First Purple 5
+    0x17D9B, // Treehouse Second Purple 1
+    0x17D99, // Treehouse Second Purple 2
+    0x17DAA, // Treehouse Second Purple 3
+    0x17D97, // Treehouse Second Purple 4
+    0x17BDF, // Treehouse Second Purple 5
+    0x17D91, // Treehouse Second Purple 6
+    0x17DC6, // Treehouse Second Purple 7
+    0x17DB3, // Treehouse Left Orange 1
+    0x17DB5, // Treehouse Left Orange 2
+    0x17DB6, // Treehouse Left Orange 3
+    0x17DC0, // Treehouse Left Orange 4
+    0x17DD7, // Treehouse Left Orange 5
+    0x17DD9, // Treehouse Left Orange 6
+    0x17DB8, // Treehouse Left Orange 7
+    0x17DDC, // Treehouse Left Orange 8
+    0x17DDE, // Treehouse Left Orange 10
+    0x17DE3, // Treehouse Left Orange 11
+    0x17DEC, // Treehouse Left Orange 12
+    0x17DAE, // Treehouse Left Orange 13
+    0x17DB0, // Treehouse Left Orange 14
+    0x17DDB, // Treehouse Left Orange 15
+    0x17D88, // Treehouse Right Orange 1
+    0x17DB4, // Treehouse Right Orange 2
+    0x17D8C, // Treehouse Right Orange 3
+    0x17DCD, // Treehouse Right Orange 5
+    0x17DB2, // Treehouse Right Orange 6
+    0x17DCC, // Treehouse Right Orange 7
+    0x17DCA, // Treehouse Right Orange 8
+    0x17D8E, // Treehouse Right Orange 9
+    0x17DB1, // Treehouse Right Orange 11
+    0x17DA2, // Treehouse Right Orange 12
+    0x17E3C, // Treehouse Green 1
+    0x17E4D, // Treehouse Green 2
+    0x17E4F, // Treehouse Green 3
+    0x17E5B, // Treehouse Green 5
+    0x17E5F, // Treehouse Green 6
+    0x17E61, // Treehouse Green 7
+    0x17FA9, // Treehouse Green Bridge Discard
+    0x00139, // Keep Hedges 1
+    0x019DC, // Keep Hedges 2
+    0x019E7, // Keep Hedges 3
+    0x01A0F, // Keep Hedges 4
+    0x17D28, // Shipwreck Discard
+    0x2899C, // Town 25 Dots 1
+    0x28A33, // Town 25 Dots 2
+    0x28ABF, // Town 25 Dots 3
+    0x28AC0, // Town 25 Dots 4
+    0x28AC1, // Town 25 Dots 5
+    0x28AC7, // Town Blue 1
+    0x28A0D, // Town Church Stars
+    0x28AD9, // Town Eraser
+    0x28998, // Town Green Door
+    0x0A0C8, // Town Orange Crate
+    0x17D01, // Town Orange Crate Discard
+    0x03C0C, // Town RGB Stones
+    0x17C71, // Town Rooftop Discard
+    0x17F89, // Theater Entrance
+    0x33AB2, // Theater Corona Exit
+    0x0A168, // Theater Sun Exit
+    0x17C2E, // Bunker Entry Door
+    0x00469, // Swamp Tutorial 1
+    0x00472, // Swamp Tutorial 2
+    0x00262, // Swamp Tutorial 3
+    0x00474, // Swamp Tutorial 4
+    0x00553, // Swamp Tutorial 5
+    0x0056F, // Swamp Tutorial 6
+    0x00390, // Swamp Tutorial 7
+    0x010CA, // Swamp Tutorial 8
+    0x00983, // Swamp Tutorial 9
+    0x00984, // Swamp Tutorial 10
+    0x00986, // Swamp Tutorial 11
+    0x00985, // Swamp Tutorial 12
+    0x00987, // Swamp Tutorial 13
+    0x181A9, // Swamp Tutorial 14
+    0x00982, // Swamp Red 1
+    0x0097F, // Swamp Red 2
+    0x0098F, // Swamp Red 3
+    0x00990, // Swamp Red 4
+    0x17C0D, // Swamp Red Shortcut 1
+    0x17C0E, // Swamp Red Shortcut 2
+    0x00999, // Swamp Discontinuous 1
+    0x0099D, // Swamp Discontinuous 2
+    0x009A0, // Swamp Discontinuous 3
+    0x009A1, // Swamp Discontinuous 4
+    0x00007, // Swamp Rotation Tutorial 1
+    0x00008, // Swamp Rotation Tutorial 2
+    0x00009, // Swamp Rotation Tutorial 3
+    0x0000A, // Swamp Rotation Tutorial 4
+    0x009AB, // Swamp Blue Underwater 1
+    0x009AD, // Swamp Blue Underwater 2
+    0x009AE, // Swamp Blue Underwater 3
+    0x009AF, // Swamp Blue Underwater 4
+    0x00006, // Swamp Blue Underwater 5
+    0x003B2, // Swamp Rotation Advanced 1
+    0x00A1E, // Swamp Rotation Advanced 2
+    0x00C2E, // Swamp Rotation Advanced 3
+    0x00E3A, // Swamp Rotation Advanced 4
+    0x009A6, // Swamp Purple Tetris
+    0x00002, // Swamp Teal Underwater 1
+    0x00004, // Swamp Teal Underwater 2
+    0x00005, // Swamp Teal Underwater 3
+    0x013E6, // Swamp Teal Underwater 4
+    0x00596, // Swamp Teal Underwater 5
+    0x00001, // Swamp Red Underwater 1
+    0x014D2, // Swamp Red Underwater 2
+    0x014D4, // Swamp Red Underwater 3
+    0x014D1, // Swamp Red Underwater 4
+    0x17C05, // Swamp Laser Shortcut 1
+    0x17C02, // Swamp Laser Shortcut 2
+    0x17F9B, // Jungle Discard
+    0x09FD3, // Mountain 2 Rainbow 1
+    0x09FD4, // Mountain 2 Rainbow 2
+    0x09FD6, // Mountain 2 Rainbow 3
+    0x09FD7, // Mountain 2 Rainbow 4
+    0x09FD8, // Mountain 2 Rainbow 5
+    0x17F93, // Mountain 2 Discard
+    0x17FA2, // Mountain 3 Secret Door
+    0x17C42, // Mountainside Discard
+    0x00FF8, // UTM Entrance Door
+    0x0A16B, // UTM Green Dots 1
+    0x0A2CE, // UTM Green Dots 2
+    0x0A2D7, // UTM Green Dots 3
+    0x0A2DD, // UTM Green Dots 4
+    0x0008F, // UTM Invisible Dots 1
+    0x0006B, // UTM Invisible Dots 2
+    0x0008B, // UTM Invisible Dots 3
+    0x0008C, // UTM Invisible Dots 4
+    0x0008A, // UTM Invisible Dots 5
+    0x00089, // UTM Invisible Dots 6
+    0x0006A, // UTM Invisible Dots 7
+    0x0006C, // UTM Invisible Dots 8
+    0x021D7, // UTM Mountainside Shortcut
+    0x00B71, // UTM Quarry
+    0x01A31, // UTM Rainbow
+    0x32962, // UTM Swamp
+    0x32966, // UTM Treehouse
+    0x17CF2, // UTM Waterfall Shortcut
+    0x00A72, // UTM Blue Cave In
+    0x009A4, // UTM Blue Discontinuous
+    0x008B8, // UTM Blue Left 1
+    0x00973, // UTM Blue Left 2
+    0x0097B, // UTM Blue Left 3
+    0x0097D, // UTM Blue Left 4
+    0x0097E, // UTM Blue Left 5
+    0x00994, // UTM Blue Right Far 1
+    0x334D5, // UTM Blue Right Far 2
+    0x00995, // UTM Blue Right Far 3
+    0x00996, // UTM Blue Right Far 4
+    0x00998, // UTM Blue Right Far 5
+    0x00190, // UTM Blue Right Near 1
+    0x006FE, // UTM Blue Right Near 4
+    0x0A16E, // UTM Challenge Entrance
+    0x039B4, // Tunnels Theater Catwalk
+
+    0x0A3B5, // Tutorial Back Left
+};
+
 std::vector<int> utmElevatorControls = {
 	0x335AB, // UTM In Elevator Control
 	0x3369D, // UTM Lower Elevator Control

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -449,6 +449,13 @@ std::vector<int> squarePanels = {
     0x09E85, // Tunnels Town Shortcut
 };
 
+std::vector<int> squarePanelsExpertBanned = {
+    0x09E7A, // Mountain 1 Green 1
+    0x09E71, // Mountain 1 Green 2
+    0x09E72, // Mountain 1 Green 3
+    0x09E69, // Mountain 1 Green 4
+    0x09E7B, // Mountain 1 Green 5
+};
 
 std::vector<int> desertPanels = {
 	0x00698, // Desert Surface 1

--- a/Source/Panels.h
+++ b/Source/Panels.h
@@ -17,27 +17,9 @@ std::vector<int> lasers = {
 	0x19650, // Shadows
 };
 
-// Note: Some of these (non-controls) are duplicated elsewhere
-// TODO: Gave up
-std::vector<int> leftRightPanels = {
-	0x01A54, // Glass Factory Entry
-	0x00086, // Glass Factory Vertical Symmetry 1
-	0x00087, // Glass Factory Vertical Symmetry 2
-	0x00059, // Glass Factory Vertical Symmetry 3
-	0x00062, // Glass Factory Vertical Symmetry 4
-	0x00025, // Symmetry Island Black Dots 4
-	0x00026, // Symmetry Island Black Dots 5
-	0x00072, // Symmetry Island Fading Lines 3
-
-	0x17D02, // Town Windmill Control
-};
-
-// Note: Some of these (non-controls) are duplicated elsewhere
-std::vector<int> upDownPanels = {
+std::vector<int> millElevatorControlOptions = {
 	0x0008D, // Glass Factory Rotational Symmetry 1
 	0x00081, // Glass Factory Rotational Symmetry 2
-	0x00083, // Glass Factory Rotational Symmetry 3
-	0x00084, // Glass Factory Melting 1
 	0x00070, // Symmetry Island Fading Lines 5
 	0x01E5A, // Mill Entry Door Left
 	0x28AC7, // Town Blue 1
@@ -46,26 +28,64 @@ std::vector<int> upDownPanels = {
 	0x28ACB, // Town Blue 4
 	0x28ACC, // Town Blue 5
 	0x00029, // UTM Invisible Dots Symmetry 3
-	0x288AA, // UTM Perspective 4
 
-	0x0A3B5, // Tutorial Back Left
 	0x17CC4, // Mill Elevator Control
-//	0x335AB, // UTM In Elevator Control
-//	0x3369D, // UTM Lower Elevator Control
-//	0x335AC, // UTM Upper Elevator Control
 };
 
-// Note: Some of these (non-controls) are duplicated elsewhere
-std::vector<int> leftForwardRightPanels = {
-	0x00075, // Symmetry Island Colored Dots 3
-	0x288EA, // UTM Perspective 1
-	0x288FC, // UTM Perspective 2
-	0x289E7, // UTM Perspective 3
+std::vector<int> tutorialBackLeftOptions = {
+	0x0008D, // Glass Factory Rotational Symmetry 1
+	0x00081, // Glass Factory Rotational Symmetry 2
+	0x00083, // Glass Factory Rotational Symmetry 3
+	0x00084, // Glass Factory Melting 1
+	0x28AC7, // Town Blue 1
+	0x28AC8, // Town Blue 2
+	0x28ACA, // Town Blue 3
+	0x28ACB, // Town Blue 4
+	0x28ACC, // Town Blue 5
+	0x00029, // UTM Invisible Dots Symmetry 3
+	0x00082, // Glass Factory Melting 2
+	0x0343A, // Glass Factory Melting 3
+	0x00022, // Symmetry Island Black Dots 1
+	0x00023, // Symmetry Island Black Dots 2
+	0x00024, // Symmetry Island Black Dots 3
+	0x00025, // Symmetry Island Black Dots 4
+	0x00026, // Symmetry Island Black Dots 5
+	0x01A0D, // UTM Blue Hard Symmetry
+	0x018A0, // UTM Blue Easy Symmetry
 
+	0x0A3B5, // Tutorial Back Left
+};
+
+std::vector<int> utmElevatorControls = {
+	0x335AB, // UTM In Elevator Control
+	0x3369D, // UTM Lower Elevator Control
+	0x335AC, // UTM Upper Elevator Control
+};
+
+std::vector<int> treehousePivotSet = {
 	0x17DD1, // Treehouse Left Orange 9
 	0x17CE3, // Treehouse Right Orange 4
 	0x17DB7, // Treehouse Right Orange 10
 	0x17E52, // Treehouse Green 4
+};
+
+std::vector<int> utmPerspectiveSet = {
+	0x288EA, // UTM Perspective 1
+	0x288FC, // UTM Perspective 2
+	0x289E7, // UTM Perspective 3
+	0x288AA, // UTM Perspective 4
+};
+
+std::vector<int> symmetryLaserYellows = {
+	0x00A52, // Symmetry Island Laser Yellow 1
+	0x00A57, // Symmetry Island Laser Yellow 2
+	0x00A5B, // Symmetry Island Laser Yellow 3
+};
+
+std::vector<int> symmetryLaserBlues = {
+	0x00A61, // Symmetry Island Laser Blue 1
+	0x00A64, // Symmetry Island Laser Blue 2
+	0x00A68, // Symmetry Island Laser Blue 3
 };
 
 std::vector<int> pillars = {
@@ -118,323 +138,317 @@ std::vector<int> mountainMultipanel = {
 };
 
 std::vector<int> squarePanels = {
-	0x00064, // Tutorial Straight
-	0x00182, // Tutorial Bend
-	0x0A3B2, // Tutorial Back Right (2 start points)
-	0x00295, // Tutorial Center Left 
-	0x00293, // Tutorial Front Center
-	0x002C2, // Tutorial Front Left (Big Maze)
-	0x0005D, // Outside Tutorial Dots Tutorial 1
-	0x0005E, // Outside Tutorial Dots Tutorial 2
-	0x0005F, // Outside Tutorial Dots Tutorial 3
-	0x00060, // Outside Tutorial Dots Tutorial 4
-	0x00061, // Outside Tutorial Dots Tutorial 5
-	0x018AF, // Outside Tutorial Stones Tutorial 1
-	0x0001B, // Outside Tutorial Stones Tutorial 2
-	0x012C9, // Outside Tutorial Stones Tutorial 3
-	0x0001C, // Outside Tutorial Stones Tutorial 4
-	0x0001D, // Outside Tutorial Stones Tutorial 5
-	0x0001E, // Outside Tutorial Stones Tutorial 6
-	0x0001F, // Outside Tutorial Stones Tutorial 7
-	0x00020, // Outside Tutorial Stones Tutorial 8
-	0x00021, // Outside Tutorial Stones Tutorial 9
-	0x033D4, // Outside Tutorial Vault
-	0x0A171, // Tutorial Optional Door 1
-	0x04CA4, // Tutorial Optional Door 2
-	0x17CFB, // Outside Tutorial Discard
-	0x3C12B, // Glass Factory Discard
-	0x01A54, // Glass Factory Entry
-	0x00086, // Glass Factory Vertical Symmetry 1
-	0x00087, // Glass Factory Vertical Symmetry 2
-	0x00059, // Glass Factory Vertical Symmetry 3
-	0x00062, // Glass Factory Vertical Symmetry 4
-	0x0008D, // Glass Factory Rotational Symmetry 1
-	0x00081, // Glass Factory Rotational Symmetry 2
-	0x00083, // Glass Factory Rotational Symmetry 3
-	0x00084, // Glass Factory Melting 1
-	0x00082, // Glass Factory Melting 2
-	0x0343A, // Glass Factory Melting 3
-	0x000B0, // Symmetry Island Door 1
-	0x00022, // Symmetry Island Black Dots 1
-	0x00023, // Symmetry Island Black Dots 2
-	0x00024, // Symmetry Island Black Dots 3
-	0x00025, // Symmetry Island Black Dots 4
-	0x00026, // Symmetry Island Black Dots 5
-	0x0007C, // Symmetry Island Colored Dots 1
-	0x0007E, // Symmetry Island Colored Dots 2
-	0x00075, // Symmetry Island Colored Dots 3
-	0x00073, // Symmetry Island Colored Dots 4
-	0x00077, // Symmetry Island Colored Dots 5
-	0x00079, // Symmetry Island Colored Dots 6
-	0x00065, // Symmetry Island Fading Lines 1
-	0x0006D, // Symmetry Island Fading Lines 2
-	0x00072, // Symmetry Island Fading Lines 3
-	0x0006F, // Symmetry Island Fading Lines 4
-	0x00070, // Symmetry Island Fading Lines 5
-	0x00071, // Symmetry Island Fading Lines 6
-	0x00076, // Symmetry Island Fading Lines 7
-	0x00A52, // Symmetry Island Laser Yellow 1
-	0x00A57, // Symmetry Island Laser Yellow 2
-	0x00A5B, // Symmetry Island Laser Yellow 3
-	0x00A61, // Symmetry Island Laser Blue 1
-	0x00A64, // Symmetry Island Laser Blue 2
-	0x00A68, // Symmetry Island Laser Blue 3
-	0x17CE7, // Desert Discard
-	0x0CC7B, // Desert Vault
-	0x01E5A, // Mill Entry Door Left
-	0x01E59, // Mill Entry Door Right
-	0x00E0C, // Mill Lower Row 1
-	0x01489, // Mill Lower Row 2
-	0x0148A, // Mill Lower Row 3
-	0x014D9, // Mill Lower Row 4
-	0x014E7, // Mill Lower Row 5
-	0x014E8, // Mill Lower Row 6
-	0x00557, // Mill Upper Row 1
-	0x005F1, // Mill Upper Row 2
-	0x00620, // Mill Upper Row 3
-	0x009F5, // Mill Upper Row 4
-	0x0146C, // Mill Upper Row 5
-	0x3C12D, // Mill Upper Row 6
-	0x03686, // Mill Upper Row 7
-	0x014E9, // Mill Upper Row 8
-	0x0367C, // Mill Control Room 1
-	0x3C125, // Mill Control Room 2
-	0x03677, // Mill Stairs Control
-	0x17CF0, // Mill Discard
-	0x03612, // Quarry Laser
-	0x021D5, // Boathouse Ramp Activation Shapers
-	0x034D4, // Boathouse Ramp Activation Stars
-	0x021B3, // Boathouse Erasers and Shapers 1
-	0x021B4, // Boathouse Erasers and Shapers 2
-	0x021B0, // Boathouse Erasers and Shapers 3
-	0x021AF, // Boathouse Erasers and Shapers 4
-	0x021AE, // Boathouse Erasers and Shapers 5
-	0x021B5, // Boathouse Erasers and Stars 1
-	0x021B6, // Boathouse Erasers and Stars 2
-	0x021B7, // Boathouse Erasers and Stars 3
-	0x021BB, // Boathouse Erasers and Stars 4
-	0x09DB5, // Boathouse Erasers and Stars 5
-	0x09DB1, // Boathouse Erasers and Stars 6
-	0x3C124, // Boathouse Erasers and Stars 7
-	0x09DB3, // Boathouse Erasers Shapers and Stars 1
-	0x09DB4, // Boathouse Erasers Shapers and Stars 2
-	0x0A3CB, // Boathouse Erasers Shapers and Stars 3
-	0x0A3CC, // Boathouse Erasers Shapers and Stars 4
-	0x0A3D0, // Boathouse Erasers Shapers and Stars 5
-	0x09E57, // Quarry Entry Gate 1
-	0x17C09, // Quarry Entry Gate 2
-	0x0288C, // Treehouse Door 1
-	0x02886, // Treehouse Door 2
-	0x17D72, // Treehouse Yellow 1
-	0x17D8F, // Treehouse Yellow 2
-	0x17D74, // Treehouse Yellow 3
-	0x17DAC, // Treehouse Yellow 4
-	0x17D9E, // Treehouse Yellow 5
-	0x17DB9, // Treehouse Yellow 6
-	0x17D9C, // Treehouse Yellow 7
-	0x17DC2, // Treehouse Yellow 8
-	0x17DC4, // Treehouse Yellow 9
-	0x0A182, // Treehouse Door 3
-	0x17DC8, // Treehouse First Purple 1
-	0x17DC7, // Treehouse First Purple 2
-	0x17CE4, // Treehouse First Purple 3
-	0x17D2D, // Treehouse First Purple 4
-	0x17D6C, // Treehouse First Purple 5
-	0x17D9B, // Treehouse Second Purple 1
-	0x17D99, // Treehouse Second Purple 2
-	0x17DAA, // Treehouse Second Purple 3
-	0x17D97, // Treehouse Second Purple 4
-	0x17BDF, // Treehouse Second Purple 5
-	0x17D91, // Treehouse Second Purple 6
-	0x17DC6, // Treehouse Second Purple 7
-	0x17DB3, // Treehouse Left Orange 1
-	0x17DB5, // Treehouse Left Orange 2
-	0x17DB6, // Treehouse Left Orange 3
-	0x17DC0, // Treehouse Left Orange 4
-	0x17DD7, // Treehouse Left Orange 5
-	0x17DD9, // Treehouse Left Orange 6
-	0x17DB8, // Treehouse Left Orange 7
-	0x17DDC, // Treehouse Left Orange 8
-	0x17DDE, // Treehouse Left Orange 10
-	0x17DE3, // Treehouse Left Orange 11
-	0x17DEC, // Treehouse Left Orange 12
-	0x17DAE, // Treehouse Left Orange 13
-	0x17DB0, // Treehouse Left Orange 14
-	0x17DDB, // Treehouse Left Orange 15
-	0x17D88, // Treehouse Right Orange 1
-	0x17DB4, // Treehouse Right Orange 2
-	0x17D8C, // Treehouse Right Orange 3
-	0x17DCD, // Treehouse Right Orange 5
-	0x17DB2, // Treehouse Right Orange 6
-	0x17DCC, // Treehouse Right Orange 7
-	0x17DCA, // Treehouse Right Orange 8
-	0x17D8E, // Treehouse Right Orange 9
-	0x17DB1, // Treehouse Right Orange 11
-	0x17DA2, // Treehouse Right Orange 12
-	0x17E3C, // Treehouse Green 1
-	0x17E4D, // Treehouse Green 2
-	0x17E4F, // Treehouse Green 3
-	0x17E5B, // Treehouse Green 5
-	0x17E5F, // Treehouse Green 6
-	0x17E61, // Treehouse Green 7
-	0x17FA9, // Treehouse Green Bridge Discard
-	0x17FA0, // Treehouse Laser Discard
-	0x00139, // Keep Hedges 1
-	0x019DC, // Keep Hedges 2
-	0x019E7, // Keep Hedges 3
-	0x01A0F, // Keep Hedges 4
-	0x0360E, // Keep Front Laser
-	0x03317, // Keep Back Laser
-	0x17D27, // Keep Discard
-	0x17D28, // Shipwreck Discard
-	0x00AFB, // Shipwreck Vault
-	0x2899C, // Town 25 Dots 1
-	0x28A33, // Town 25 Dots 2
-	0x28ABF, // Town 25 Dots 3
-	0x28AC0, // Town 25 Dots 4
-	0x28AC1, // Town 25 Dots 5
-	0x28938, // Town Apple Tree
-	0x28AC7, // Town Blue 1
-	0x28AC8, // Town Blue 2
-	0x28ACA, // Town Blue 3
-	0x28ACB, // Town Blue 4
-	0x28ACC, // Town Blue 5
-	0x28A0D, // Town Church Stars
-	0x28AD9, // Town Eraser
-	0x28998, // Town Yellow Door
-	0x0A0C8, // Town Orange Crate
-	0x17D01, // Town Orange Crate Discard
-	0x03C08, // Town RGB Stars
-	0x03C0C, // Town RGB Stones
-	0x17C71, // Town Rooftop Discard
-	0x17F5F, // Town Windmill Door
-	0x17F89, // Theater Entrance
-	0x17CF7, // Theater Discard
-	0x33AB2, // Theater Corona Exit
-	0x0A168, // Theater Sun Exit
-	0x00B10, // Monastery Left Door
-	0x00C92, // Monastery Right Door
-	0x17C2E, // Bunker Entry Door
-	0x0056E, // Swamp Entry
-	0x00469, // Swamp Tutorial 1
-	0x00472, // Swamp Tutorial 2
-	0x00262, // Swamp Tutorial 3
-	0x00474, // Swamp Tutorial 4
-	0x00553, // Swamp Tutorial 5
-	0x0056F, // Swamp Tutorial 6
-	0x00390, // Swamp Tutorial 7
-	0x010CA, // Swamp Tutorial 8
-	0x00983, // Swamp Tutorial 9
-	0x00984, // Swamp Tutorial 10
-	0x00986, // Swamp Tutorial 11
-	0x00985, // Swamp Tutorial 12
-	0x00987, // Swamp Tutorial 13
-	0x181A9, // Swamp Tutorial 14
-	0x00982, // Swamp Red 1
-	0x0097F, // Swamp Red 2
-	0x0098F, // Swamp Red 3
-	0x00990, // Swamp Red 4
-	0x17C0D, // Swamp Red Shortcut 1
-	0x17C0E, // Swamp Red Shortcut 2
-	0x00999, // Swamp Discontinuous 1
-	0x0099D, // Swamp Discontinuous 2
-	0x009A0, // Swamp Discontinuous 3
-	0x009A1, // Swamp Discontinuous 4
-	0x00007, // Swamp Rotation Tutorial 1
-	0x00008, // Swamp Rotation Tutorial 2
-	0x00009, // Swamp Rotation Tutorial 3
-	0x0000A, // Swamp Rotation Tutorial 4
-	0x009AB, // Swamp Blue Underwater 1
-	0x009AD, // Swamp Blue Underwater 2
-	0x009AE, // Swamp Blue Underwater 3
-	0x009AF, // Swamp Blue Underwater 4
-	0x00006, // Swamp Blue Underwater 5
-	0x003B2, // Swamp Rotation Advanced 1
-	0x00A1E, // Swamp Rotation Advanced 2
-	0x00C2E, // Swamp Rotation Advanced 3
-	0x00E3A, // Swamp Rotation Advanced 4
-	0x009A6, // Swamp Purple Tetris
-	0x00002, // Swamp Teal Underwater 1
-	0x00004, // Swamp Teal Underwater 2
-	0x00005, // Swamp Teal Underwater 3
-	0x013E6, // Swamp Teal Underwater 4
-	0x00596, // Swamp Teal Underwater 5
-	0x00001, // Swamp Red Underwater 1
-	0x014D2, // Swamp Red Underwater 2
-	0x014D4, // Swamp Red Underwater 3
-	0x014D1, // Swamp Red Underwater 4
-	0x17C05, // Swamp Laser Shortcut 1
-	0x17C02, // Swamp Laser Shortcut 2
-	0x17F9B, // Jungle Discard
-	0x09E73, // Mountain 1 Orange 1
-	0x09E75, // Mountain 1 Orange 2
-	0x09E78, // Mountain 1 Orange 3
-	0x09E79, // Mountain 1 Orange 4
-	0x09E6C, // Mountain 1 Orange 5
-	0x09E6F, // Mountain 1 Orange 6
-	0x09E6B, // Mountain 1 Orange 7
-	0x09EAD, // Mountain 1 Purple 1
-	0x09EAF, // Mountain 1 Purple 2
-	0x09E7A, // Mountain 1 Green 1
-	0x09E71, // Mountain 1 Green 2
-	0x09E72, // Mountain 1 Green 3
-	0x09E69, // Mountain 1 Green 4
-	0x09E7B, // Mountain 1 Green 5
-	0x09FD3, // Mountain 2 Rainbow 1
-	0x09FD4, // Mountain 2 Rainbow 2
-	0x09FD6, // Mountain 2 Rainbow 3
-	0x09FD7, // Mountain 2 Rainbow 4
-	0x17F93, // Mountain 2 Discard
-	0x17FA2, // Mountain 3 Secret Door
-	0x17C42, // Mountainside Discard
-	0x002A6, // Mountainside Vault
-	0x0042D, // Mountaintop River
-	0x00FF8, // UTM Entrance Door
-	0x0A16B, // UTM Green Dots 1
-	0x0A2CE, // UTM Green Dots 2
-	0x0A2D7, // UTM Green Dots 3
-	0x0A2DD, // UTM Green Dots 4
-	0x0A2EA, // UTM Green Dots 5
-	0x17FB9, // UTM Green Dots 6
-	0x0008F, // UTM Invisible Dots 1
-	0x0006B, // UTM Invisible Dots 2
-	0x0008B, // UTM Invisible Dots 3
-	0x0008C, // UTM Invisible Dots 4
-	0x0008A, // UTM Invisible Dots 5
-	0x00089, // UTM Invisible Dots 6
-	0x0006A, // UTM Invisible Dots 7
-	0x0006C, // UTM Invisible Dots 8
-	0x00027, // UTM Invisible Dots Symmetry 1
-	0x00028, // UTM Invisible Dots Symmetry 2
-	0x00029, // UTM Invisible Dots Symmetry 3
-	0x021D7, // UTM Mountainside Shortcut
-	0x00B71, // UTM Quarry
-	0x01A31, // UTM Rainbow
-	0x32962, // UTM Swamp
-	0x32966, // UTM Treehouse
-	0x17CF2, // UTM Waterfall Shortcut
-	0x00A72, // UTM Blue Cave In
-	0x009A4, // UTM Blue Discontinuous
-	0x018A0, // UTM Blue Easy Symmetry
-	0x01A0D, // UTM Blue Hard Symmetry
-	0x008B8, // UTM Blue Left 1
-	0x00973, // UTM Blue Left 2
-	0x0097B, // UTM Blue Left 3
-	0x0097D, // UTM Blue Left 4
-	0x0097E, // UTM Blue Left 5
-	0x00994, // UTM Blue Right Far 1
-	0x334D5, // UTM Blue Right Far 2
-	0x00995, // UTM Blue Right Far 3
-	0x00996, // UTM Blue Right Far 4
-	0x00998, // UTM Blue Right Far 5
-	0x00190, // UTM Blue Right Near 1
-	0x00558, // UTM Blue Right Near 2
-	0x00567, // UTM Blue Right Near 3
-	0x006FE, // UTM Blue Right Near 4
-	0x0A16E, // UTM Challenge Entrance
-	0x039B4, // Tunnels Theater Catwalk
-	0x09E85, // Tunnels Town Shortcut
+    0x00064, // Tutorial Straight
+    0x00182, // Tutorial Bend
+    0x0A3B2, // Tutorial Back Right
+    0x00295, // Tutorial Center Left
+    0x00293, // Tutorial Front Center
+    0x002C2, // Tutorial Front Left
+    0x0005D, // Outside Tutorial Dots Tutorial 1
+    0x0005E, // Outside Tutorial Dots Tutorial 2
+    0x0005F, // Outside Tutorial Dots Tutorial 3
+    0x00060, // Outside Tutorial Dots Tutorial 4
+    0x00061, // Outside Tutorial Dots Tutorial 5
+    0x018AF, // Outside Tutorial Stones Tutorial 1
+    0x0001B, // Outside Tutorial Stones Tutorial 2
+    0x012C9, // Outside Tutorial Stones Tutorial 3
+    0x0001C, // Outside Tutorial Stones Tutorial 4
+    0x0001D, // Outside Tutorial Stones Tutorial 5
+    0x0001E, // Outside Tutorial Stones Tutorial 6
+    0x0001F, // Outside Tutorial Stones Tutorial 7
+    0x00020, // Outside Tutorial Stones Tutorial 8
+    0x00021, // Outside Tutorial Stones Tutorial 9
+    0x033D4, // Outside Tutorial Vault
+    0x0A171, // Tutorial Optional Door 1
+    0x04CA4, // Tutorial Optional Door 2
+    0x17CFB, // Outside Tutorial Discard
+    0x3C12B, // Glass Factory Discard
+    0x01A54, // Glass Factory Entry
+    0x00086, // Glass Factory Vertical Symmetry 1
+    0x00087, // Glass Factory Vertical Symmetry 2
+    0x00059, // Glass Factory Vertical Symmetry 3
+    0x00062, // Glass Factory Vertical Symmetry 4
+    0x0008D, // Glass Factory Rotational Symmetry 1
+    0x00081, // Glass Factory Rotational Symmetry 2
+    0x00083, // Glass Factory Rotational Symmetry 3
+    0x00084, // Glass Factory Melting 1
+    0x00082, // Glass Factory Melting 2
+    0x0343A, // Glass Factory Melting 3
+    0x000B0, // Symmetry Island Door 1
+    0x00022, // Symmetry Island Black Dots 1
+    0x00023, // Symmetry Island Black Dots 2
+    0x00024, // Symmetry Island Black Dots 3
+    0x00025, // Symmetry Island Black Dots 4
+    0x00026, // Symmetry Island Black Dots 5
+    0x0007C, // Symmetry Island Colored Dots 1
+    0x0007E, // Symmetry Island Colored Dots 2
+    0x00075, // Symmetry Island Colored Dots 3
+    0x00073, // Symmetry Island Colored Dots 4
+    0x00077, // Symmetry Island Colored Dots 5
+    0x00079, // Symmetry Island Colored Dots 6
+    0x00065, // Symmetry Island Fading Lines 1
+    0x0006D, // Symmetry Island Fading Lines 2
+    0x00072, // Symmetry Island Fading Lines 3
+    0x0006F, // Symmetry Island Fading Lines 4
+    0x00070, // Symmetry Island Fading Lines 5
+    0x00071, // Symmetry Island Fading Lines 6
+    0x00076, // Symmetry Island Fading Lines 7
+    0x17CE7, // Desert Discard
+    0x0CC7B, // Desert Vault
+    0x01E5A, // Mill Entry Door Left
+    0x01E59, // Mill Entry Door Right
+    0x00E0C, // Mill Lower Row 1
+    0x01489, // Mill Lower Row 2
+    0x0148A, // Mill Lower Row 3
+    0x014D9, // Mill Lower Row 4
+    0x014E7, // Mill Lower Row 5
+    0x014E8, // Mill Lower Row 6
+    0x00557, // Mill Upper Row 1
+    0x005F1, // Mill Upper Row 2
+    0x00620, // Mill Upper Row 3
+    0x009F5, // Mill Upper Row 4
+    0x0146C, // Mill Upper Row 5
+    0x3C12D, // Mill Upper Row 6
+    0x03686, // Mill Upper Row 7
+    0x014E9, // Mill Upper Row 8
+    0x0367C, // Mill Control Room 1
+    0x3C125, // Mill Control Room 2
+    0x03677, // Mill Stairs Control
+    0x17CF0, // Mill Discard
+    0x021D5, // Boathouse Ramp Activation Shapers
+    0x034D4, // Boathouse Ramp Activation Stars
+    0x021B3, // Boathouse Erasers and Shapers 1
+    0x021B4, // Boathouse Erasers and Shapers 2
+    0x021B0, // Boathouse Erasers and Shapers 3
+    0x021AF, // Boathouse Erasers and Shapers 4
+    0x021AE, // Boathouse Erasers and Shapers 5
+    0x021B5, // Boathouse Erasers and Stars 1
+    0x021B6, // Boathouse Erasers and Stars 2
+    0x021B7, // Boathouse Erasers and Stars 3
+    0x021BB, // Boathouse Erasers and Stars 4
+    0x09DB5, // Boathouse Erasers and Stars 5
+    0x09DB1, // Boathouse Erasers and Stars 6
+    0x3C124, // Boathouse Erasers and Stars 7
+    0x09DB3, // Boathouse Erasers Shapers and Stars 1
+    0x09DB4, // Boathouse Erasers Shapers and Stars 2
+    0x0A3CB, // Boathouse Erasers Shapers and Stars 3
+    0x0A3CC, // Boathouse Erasers Shapers and Stars 4
+    0x0A3D0, // Boathouse Erasers Shapers and Stars 5
+    0x09E57, // Quarry Entry Gate 1
+    0x17C09, // Quarry Entry Gate 2
+    0x0288C, // Treehouse Door 1
+    0x02886, // Treehouse Door 2
+    0x17D72, // Treehouse Yellow 1
+    0x17D8F, // Treehouse Yellow 2
+    0x17D74, // Treehouse Yellow 3
+    0x17DAC, // Treehouse Yellow 4
+    0x17D9E, // Treehouse Yellow 5
+    0x17DB9, // Treehouse Yellow 6
+    0x17D9C, // Treehouse Yellow 7
+    0x17DC2, // Treehouse Yellow 8
+    0x17DC4, // Treehouse Yellow 9
+    0x0A182, // Treehouse Door 3
+    0x17DC8, // Treehouse First Purple 1
+    0x17DC7, // Treehouse First Purple 2
+    0x17CE4, // Treehouse First Purple 3
+    0x17D2D, // Treehouse First Purple 4
+    0x17D6C, // Treehouse First Purple 5
+    0x17D9B, // Treehouse Second Purple 1
+    0x17D99, // Treehouse Second Purple 2
+    0x17DAA, // Treehouse Second Purple 3
+    0x17D97, // Treehouse Second Purple 4
+    0x17BDF, // Treehouse Second Purple 5
+    0x17D91, // Treehouse Second Purple 6
+    0x17DC6, // Treehouse Second Purple 7
+    0x17DB3, // Treehouse Left Orange 1
+    0x17DB5, // Treehouse Left Orange 2
+    0x17DB6, // Treehouse Left Orange 3
+    0x17DC0, // Treehouse Left Orange 4
+    0x17DD7, // Treehouse Left Orange 5
+    0x17DD9, // Treehouse Left Orange 6
+    0x17DB8, // Treehouse Left Orange 7
+    0x17DDC, // Treehouse Left Orange 8
+    0x17DDE, // Treehouse Left Orange 10
+    0x17DE3, // Treehouse Left Orange 11
+    0x17DEC, // Treehouse Left Orange 12
+    0x17DAE, // Treehouse Left Orange 13
+    0x17DB0, // Treehouse Left Orange 14
+    0x17DDB, // Treehouse Left Orange 15
+    0x17D88, // Treehouse Right Orange 1
+    0x17DB4, // Treehouse Right Orange 2
+    0x17D8C, // Treehouse Right Orange 3
+    0x17DCD, // Treehouse Right Orange 5
+    0x17DB2, // Treehouse Right Orange 6
+    0x17DCC, // Treehouse Right Orange 7
+    0x17DCA, // Treehouse Right Orange 8
+    0x17D8E, // Treehouse Right Orange 9
+    0x17DB1, // Treehouse Right Orange 11
+    0x17DA2, // Treehouse Right Orange 12
+    0x17E3C, // Treehouse Green 1
+    0x17E4D, // Treehouse Green 2
+    0x17E4F, // Treehouse Green 3
+    0x17E5B, // Treehouse Green 5
+    0x17E5F, // Treehouse Green 6
+    0x17E61, // Treehouse Green 7
+    0x17FA9, // Treehouse Green Bridge Discard
+    0x17FA0, // Treehouse Laser Discard
+    0x00139, // Keep Hedges 1
+    0x019DC, // Keep Hedges 2
+    0x019E7, // Keep Hedges 3
+    0x01A0F, // Keep Hedges 4
+    0x0360E, // Keep Front Laser
+    0x03317, // Keep Back Laser
+    0x17D27, // Keep Discard
+    0x17D28, // Shipwreck Discard
+    0x00AFB, // Shipwreck Vault
+    0x2899C, // Town 25 Dots 1
+    0x28A33, // Town 25 Dots 2
+    0x28ABF, // Town 25 Dots 3
+    0x28AC0, // Town 25 Dots 4
+    0x28AC1, // Town 25 Dots 5
+    0x28938, // Town Apple Tree
+    0x28AC7, // Town Blue 1
+    0x28AC8, // Town Blue 2
+    0x28ACA, // Town Blue 3
+    0x28ACB, // Town Blue 4
+    0x28ACC, // Town Blue 5
+    0x28A0D, // Town Church Stars
+    0x28AD9, // Town Eraser
+    0x28998, // Town Green Door
+    0x0A0C8, // Town Orange Crate
+    0x17D01, // Town Orange Crate Discard
+    0x03C08, // Town RGB Stars
+    0x03C0C, // Town RGB Stones
+    0x17C71, // Town Rooftop Discard
+    0x17F5F, // Town Windmill Door
+    0x17F89, // Theater Entrance
+    0x17CF7, // Theater Discard
+    0x33AB2, // Theater Corona Exit
+    0x0A168, // Theater Sun Exit
+    0x00B10, // Monastery Left Door
+    0x00C92, // Monastery Right Door
+    0x17C2E, // Bunker Entry Door
+    0x00469, // Swamp Tutorial 1
+    0x00472, // Swamp Tutorial 2
+    0x00262, // Swamp Tutorial 3
+    0x00474, // Swamp Tutorial 4
+    0x00553, // Swamp Tutorial 5
+    0x0056F, // Swamp Tutorial 6
+    0x00390, // Swamp Tutorial 7
+    0x010CA, // Swamp Tutorial 8
+    0x00983, // Swamp Tutorial 9
+    0x00984, // Swamp Tutorial 10
+    0x00986, // Swamp Tutorial 11
+    0x00985, // Swamp Tutorial 12
+    0x00987, // Swamp Tutorial 13
+    0x181A9, // Swamp Tutorial 14
+    0x00982, // Swamp Red 1
+    0x0097F, // Swamp Red 2
+    0x0098F, // Swamp Red 3
+    0x00990, // Swamp Red 4
+    0x17C0D, // Swamp Red Shortcut 1
+    0x17C0E, // Swamp Red Shortcut 2
+    0x00999, // Swamp Discontinuous 1
+    0x0099D, // Swamp Discontinuous 2
+    0x009A0, // Swamp Discontinuous 3
+    0x009A1, // Swamp Discontinuous 4
+    0x00007, // Swamp Rotation Tutorial 1
+    0x00008, // Swamp Rotation Tutorial 2
+    0x00009, // Swamp Rotation Tutorial 3
+    0x0000A, // Swamp Rotation Tutorial 4
+    0x009AB, // Swamp Blue Underwater 1
+    0x009AD, // Swamp Blue Underwater 2
+    0x009AE, // Swamp Blue Underwater 3
+    0x009AF, // Swamp Blue Underwater 4
+    0x00006, // Swamp Blue Underwater 5
+    0x003B2, // Swamp Rotation Advanced 1
+    0x00A1E, // Swamp Rotation Advanced 2
+    0x00C2E, // Swamp Rotation Advanced 3
+    0x00E3A, // Swamp Rotation Advanced 4
+    0x009A6, // Swamp Purple Tetris
+    0x00002, // Swamp Teal Underwater 1
+    0x00004, // Swamp Teal Underwater 2
+    0x00005, // Swamp Teal Underwater 3
+    0x013E6, // Swamp Teal Underwater 4
+    0x00596, // Swamp Teal Underwater 5
+    0x00001, // Swamp Red Underwater 1
+    0x014D2, // Swamp Red Underwater 2
+    0x014D4, // Swamp Red Underwater 3
+    0x014D1, // Swamp Red Underwater 4
+    0x17C05, // Swamp Laser Shortcut 1
+    0x17C02, // Swamp Laser Shortcut 2
+    0x17F9B, // Jungle Discard
+    0x09E73, // Mountain 1 Orange 1
+    0x09E75, // Mountain 1 Orange 2
+    0x09E78, // Mountain 1 Orange 3
+    0x09E79, // Mountain 1 Orange 4
+    0x09E6C, // Mountain 1 Orange 5
+    0x09E6F, // Mountain 1 Orange 6
+    0x09E6B, // Mountain 1 Orange 7
+    0x09EAD, // Mountain 1 Purple 1
+    0x09EAF, // Mountain 1 Purple 2
+    0x09E7A, // Mountain 1 Green 1
+    0x09E71, // Mountain 1 Green 2
+    0x09E72, // Mountain 1 Green 3
+    0x09E69, // Mountain 1 Green 4
+    0x09E7B, // Mountain 1 Green 5
+    0x09FD3, // Mountain 2 Rainbow 1
+    0x09FD4, // Mountain 2 Rainbow 2
+    0x09FD6, // Mountain 2 Rainbow 3
+    0x09FD7, // Mountain 2 Rainbow 4
+    0x09FD8, // Mountain 2 Rainbow 5
+    0x17F93, // Mountain 2 Discard
+    0x17FA2, // Mountain 3 Secret Door
+    0x17C42, // Mountainside Discard
+    0x002A6, // Mountainside Vault
+    0x0042D, // Mountaintop River
+    0x00FF8, // UTM Entrance Door
+    0x0A16B, // UTM Green Dots 1
+    0x0A2CE, // UTM Green Dots 2
+    0x0A2D7, // UTM Green Dots 3
+    0x0A2DD, // UTM Green Dots 4
+    0x0A2EA, // UTM Green Dots 5
+    0x17FB9, // UTM Green Dots 6
+    0x0008F, // UTM Invisible Dots 1
+    0x0006B, // UTM Invisible Dots 2
+    0x0008B, // UTM Invisible Dots 3
+    0x0008C, // UTM Invisible Dots 4
+    0x0008A, // UTM Invisible Dots 5
+    0x00089, // UTM Invisible Dots 6
+    0x0006A, // UTM Invisible Dots 7
+    0x0006C, // UTM Invisible Dots 8
+    0x00027, // UTM Invisible Dots Symmetry 1
+    0x00028, // UTM Invisible Dots Symmetry 2
+    0x00029, // UTM Invisible Dots Symmetry 3
+    0x021D7, // UTM Mountainside Shortcut
+    0x00B71, // UTM Quarry
+    0x01A31, // UTM Rainbow
+    0x32962, // UTM Swamp
+    0x32966, // UTM Treehouse
+    0x17CF2, // UTM Waterfall Shortcut
+    0x00A72, // UTM Blue Cave In
+    0x009A4, // UTM Blue Discontinuous
+    0x018A0, // UTM Blue Easy Symmetry
+    0x01A0D, // UTM Blue Hard Symmetry
+    0x008B8, // UTM Blue Left 1
+    0x00973, // UTM Blue Left 2
+    0x0097B, // UTM Blue Left 3
+    0x0097D, // UTM Blue Left 4
+    0x0097E, // UTM Blue Left 5
+    0x00994, // UTM Blue Right Far 1
+    0x334D5, // UTM Blue Right Far 2
+    0x00995, // UTM Blue Right Far 3
+    0x00996, // UTM Blue Right Far 4
+    0x00998, // UTM Blue Right Far 5
+    0x00190, // UTM Blue Right Near 1
+    0x00558, // UTM Blue Right Near 2
+    0x00567, // UTM Blue Right Near 3
+    0x006FE, // UTM Blue Right Near 4
+    0x0A16E, // UTM Challenge Entrance
+    0x039B4, // Tunnels Theater Catwalk
+    0x09E85, // Tunnels Town Shortcut
 };
+
 
 std::vector<int> desertPanels = {
 	0x00698, // Desert Surface 1
@@ -463,6 +477,27 @@ std::vector<int> desertPanels = {
 //	0x09FFF, // Desert Final Left Concave
 //	0x0A15F, // Desert Final Near
 	0x012D7, // Desert Final Far
+};
+
+std::vector<int> desertPanelsWide = {
+    0x0A15C, //wide desert panel curve 1
+    0x09FFF, //wide desert panel curve 2
+};
+
+std::vector<int> orchard{
+    0x00143, // Orchard Apple Tree 1
+    0x0003B, // Orchard Apple Tree 2
+    0x00055, // Orchard Apple Tree 3
+    0x032F7, // Orchard Apple Tree 4
+    0x032FF, // Orchard Apple Tree 5
+};
+
+std::vector<int> transparent = {
+    0x009B8, // Symmetry Island Transparent 1
+    0x003E8, // Symmetry Island Transparent 2
+    0x00A15, // Symmetry Island Transparent 3
+    0x00B53, // Symmetry Island Transparent 4
+    0x00B8D, // Symmetry Island Transparent 5
 };
 
 std::vector<int> shadowsPanels = {

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -332,8 +332,6 @@ void Randomizer::ShufflePanels(bool hard) {
 	// Jungle.
 	std::vector<int> jungleRandomOrder(junglePanels.size(), 0);
 	std::iota(jungleRandomOrder.begin(), jungleRandomOrder.end(), 0);
-	// Waves 1 cannot be randomized, since no other panel can start on
-	ShuffleRange(jungleRandomOrder, 1, 7); // Waves 2-7
 	ShuffleRange(jungleRandomOrder, 8, 13); // Pitches 1-6
 	ReassignTargets(junglePanels, jungleRandomOrder);
 

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -284,7 +284,11 @@ void Randomizer::ShufflePanels(bool hard) {
 		Randomize(squarePanels, SWAP::LINES | SWAP::COLORS);
 	} else {
 		std::vector<int> panelsToRandom = copyWithoutElements(squarePanels, squarePanelsExpertBanned);
-		Randomize(panelsToRandom, SWAP::LINES | SWAP::COLORS);
+		std::vector<int> firstPass = copyWithoutElements(panelsToRandom, arrowPanels);
+		std::vector<int> secondPass = copyWithoutElements(panelsToRandom, glassPanels);
+
+		Randomize(firstPass, SWAP::LINES | SWAP::COLORS);
+		Randomize(secondPass, SWAP::LINES | SWAP::COLORS);
 	}
 	Randomize(desertPanelsWide, SWAP::LINES);
 	Randomize(mountainMultipanel, SWAP::LINES | SWAP::COLORS);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -295,21 +295,6 @@ void Randomizer::ShufflePanels(bool hard) {
 	ShuffleRange(transparentRandomOrder, 1, 5);
 	ReassignTargets(transparent, transparentRandomOrder);
 
-	// Change the shadows tutorial cable to only activate avoid
-	_memory->WritePanelData<int>(0x319A8, CABLE_TARGET_2, { 0 });
-	// Change shadows avoid 8 to power shadows follow
-	_memory->WritePanelData<int>(0x1972F, TARGET, { 0x1C34C });
-	std::vector<int> shadowsRandomOrder(shadowsPanels.size(), 0);
-	std::iota(shadowsRandomOrder.begin(), shadowsRandomOrder.end(), 0);
-	ShuffleRange(shadowsRandomOrder, 0, 8); // Tutorial
-	ShuffleRange(shadowsRandomOrder, 8, 16); // Avoid
-	ShuffleRange(shadowsRandomOrder, 16, 21); // Follow
-	ReassignTargets(shadowsPanels, shadowsRandomOrder);
-	// Turn off original starting panel
-	_memory->WritePanelData<float>(shadowsPanels[0], POWER, { 0.0f, 0.0f });
-	// Turn on new starting panel
-	_memory->WritePanelData<float>(shadowsPanels[shadowsRandomOrder[0]], POWER, { 1.0f, 1.0f });
-
 	// Orchard.
 	std::vector<int> orchardRandomOrder(orchard.size() + 1, 0);
 	std::iota(orchardRandomOrder.begin(), orchardRandomOrder.end(), 0);
@@ -370,9 +355,4 @@ void Randomizer::ShufflePanels(bool hard) {
 	// Turn on new starting panels
 	_memory->WritePanelData<float>(pillars[pillarRandomOrder[0]], POWER, { 1.0f, 1.0f });
 	_memory->WritePanelData<float>(pillars[pillarRandomOrder[5]], POWER, { 1.0f, 1.0f });
-
-	// Distance-gate swamp snipe 1 to prevent RNG swamp snipe
-	_memory->WritePanelData<float>(0x17C05, MAX_BROADCAST_DISTANCE, { 15.0 });
-	// Distance-gate shadows laser to prevent sniping through the bars
-	_memory->WritePanelData<float>(0x19650, MAX_BROADCAST_DISTANCE, { 2.5 });
 }

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -270,7 +270,6 @@ void Randomizer::ShufflePanels(bool hard) {
 	_alreadySwapped.clear();
 
 	// General shuffles.
-	SwapWithRandomPanel(0x17CC4, millElevatorControlOptions, SWAP::LINES | SWAP::COLORS); // Mill Elevator Control
 	if (hard) {
 		SwapWithRandomPanel(0x0A3B5, tutorialBackLeftExpertOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
 	} else {

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -318,6 +318,11 @@ void Randomizer::ShufflePanels(bool hard) {
 	orchardRandomOrder[max(panel3Index, panel4Index)] = 4;
 	ReassignTargets(orchard, orchardRandomOrder);
 
+	// Don't power off Town Apple Tree on fail on Expert.
+	if (hard) {
+		_memory->WritePanelData<int>(0x28938, POWER_OFF_ON_FAIL, { 0 });
+	}
+
 	// Monastery.
 	std::vector<int> monasteryRandomOrder(monasteryPanels.size(), 0);
 	std::iota(monasteryRandomOrder.begin(), monasteryRandomOrder.end(), 0);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -17,7 +17,7 @@ void Randomizer::GenerateNormal(HWND loadingHandle) {
 	puzzles->setLoadingHandle(loadingHandle);
 	puzzles->setSeed(seed, seedIsRNG, colorblind);
 	puzzles->GenerateAllN();
-	if (doubleMode) ShufflePanels();
+	if (doubleMode) ShufflePanels(false);
 }
 
 void Randomizer::GenerateHard(HWND loadingHandle) {
@@ -25,7 +25,10 @@ void Randomizer::GenerateHard(HWND loadingHandle) {
 	puzzles->setLoadingHandle(loadingHandle);
 	puzzles->setSeed(seed, seedIsRNG, colorblind);
 	puzzles->GenerateAllH();
-	if (doubleMode) ShufflePanels();
+	if (doubleMode) ShufflePanels(true);
+	SetWindowText(loadingHandle, L"Starting watchdogs...");
+	Panel::StartArrowWatchdogs(_shuffleMapping);
+	SetWindowText(loadingHandle, L"Done!");
 	if (!Special::hasBeenRandomized())
 		MessageBox(GetActiveWindow(), L"Hi there! Thanks for trying out Expert Mode. It will be tough, but I hope you have fun!\r\n\r\n"
 		L"Expert has some unique tricks up its sleeve. You will encounter some situations that may seem impossible at first glance. "
@@ -100,7 +103,7 @@ void Randomizer::Randomize(std::vector<int>& panels, int flags) {
 }
 
 // Range is [start, end)
-void Randomizer::RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex) {
+void Randomizer::RandomizeRange(std::vector<int> panels, int flags, size_t startIndex, size_t endIndex) {
 	if (panels.size() == 0) return;
 	if (startIndex >= endIndex) return;
 	if (endIndex >= panels.size()) endIndex = static_cast<int>(panels.size());
@@ -173,6 +176,7 @@ void Randomizer::SwapPanels(int panel1, int panel2, int flags) {
 		offsets[COLORED_REGIONS] = sizeof(void*);
 	}
 	if (flags & SWAP::LINES) {
+		offsets[TRACED_EDGES] = 16;
 		offsets[AUDIO_PREFIX] = sizeof(void*);
 		offsets[PATH_WIDTH_SCALE] = sizeof(float);
 		offsets[STARTPOINT_SCALE] = sizeof(float);
@@ -251,7 +255,7 @@ void Randomizer::ShuffleRange(std::vector<int>& order, size_t startIndex, size_t
 	}
 }
 
-void Randomizer::ShufflePanels() {
+void Randomizer::ShufflePanels(bool hard) {
 	_alreadySwapped.clear();
 
 	// General shuffles.
@@ -260,8 +264,10 @@ void Randomizer::ShufflePanels() {
 	Randomize(utmElevatorControls, SWAP::LINES | SWAP::COLORS);
 	Randomize(treehousePivotSet, SWAP::LINES | SWAP::COLORS);
 	Randomize(utmPerspectiveSet, SWAP::LINES | SWAP::COLORS);
-	Randomize(symmetryLaserYellows, SWAP::LINES | SWAP::COLORS);
-	Randomize(symmetryLaserBlues, SWAP::LINES | SWAP::COLORS);
+	if (!hard) {
+		Randomize(symmetryLaserYellows, SWAP::LINES | SWAP::COLORS);
+		Randomize(symmetryLaserBlues, SWAP::LINES | SWAP::COLORS);
+	}
 	Randomize(squarePanels, SWAP::LINES | SWAP::COLORS);
 	Randomize(desertPanelsWide, SWAP::LINES);
 	Randomize(mountainMultipanel, SWAP::LINES | SWAP::COLORS);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -271,7 +271,11 @@ void Randomizer::ShufflePanels(bool hard) {
 
 	// General shuffles.
 	SwapWithRandomPanel(0x17CC4, millElevatorControlOptions, SWAP::LINES | SWAP::COLORS); // Mill Elevator Control
-	SwapWithRandomPanel(0x0A3B5, tutorialBackLeftOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
+	if (hard) {
+		SwapWithRandomPanel(0x0A3B5, tutorialBackLeftExpertOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
+	} else {
+		SwapWithRandomPanel(0x0A3B5, tutorialBackLeftOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
+	}
 	Randomize(utmElevatorControls, SWAP::LINES | SWAP::COLORS);
 	Randomize(treehousePivotSet, SWAP::LINES | SWAP::COLORS);
 	Randomize(utmPerspectiveSet, SWAP::LINES | SWAP::COLORS);

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -12,6 +12,17 @@
 #include "Random.h"
 #include "Quaternion.h"
 
+std::vector<int> copyWithoutElements(const std::vector<int>& input, const std::vector<int>& toRemove) {
+	std::vector<int> result;
+	result.reserve(input.size());
+	for (int val : input) {
+		if (std::find(toRemove.begin(), toRemove.end(), val) == toRemove.end()) {
+			result.push_back(val);
+		}
+	}
+	return result;
+}
+
 void Randomizer::GenerateNormal(HWND loadingHandle) {
 	std::shared_ptr<PuzzleList> puzzles = std::make_shared<PuzzleList>();
 	puzzles->setLoadingHandle(loadingHandle);
@@ -267,8 +278,11 @@ void Randomizer::ShufflePanels(bool hard) {
 	if (!hard) {
 		Randomize(symmetryLaserYellows, SWAP::LINES | SWAP::COLORS);
 		Randomize(symmetryLaserBlues, SWAP::LINES | SWAP::COLORS);
+		Randomize(squarePanels, SWAP::LINES | SWAP::COLORS);
+	} else {
+		std::vector<int> panelsToRandom = copyWithoutElements(squarePanels, squarePanelsExpertBanned);
+		Randomize(panelsToRandom, SWAP::LINES | SWAP::COLORS);
 	}
-	Randomize(squarePanels, SWAP::LINES | SWAP::COLORS);
 	Randomize(desertPanelsWide, SWAP::LINES);
 	Randomize(mountainMultipanel, SWAP::LINES | SWAP::COLORS);
 

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -30,13 +30,13 @@ private:
 	void RandomizeDesert();
 
 	void Randomize(std::vector<int>& panels, int flags);
-	void RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex);
+	void RandomizeRange(std::vector<int> panels, int flags, size_t startIndex, size_t endIndex);
 	void RandomizeAudiologs();
 	void SwapPanels(int panel1, int panel2, int flags);
 	void ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets = {});
 	void SwapWithRandomPanel(int panel1, const std::vector<int>& possiblePanels, int flags);
 	void ShuffleRange(std::vector<int>& order, size_t startIndex, size_t endIndex);
-	void ShufflePanels();
+	void ShufflePanels(bool hard);
 
 	std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe");
 	std::set<int> _alreadySwapped;

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "Memory.h"
 #include <memory>
+#include <set>
+#include <map>
 
 class Randomizer {
 public:
@@ -22,6 +24,7 @@ public:
 	int seed = 0;
 	bool seedIsRNG = false;
 	bool colorblind = false;
+	bool doubleMode = false;
 
 private:
 	void RandomizeDesert();
@@ -30,8 +33,14 @@ private:
 	void RandomizeRange(std::vector<int> &panels, int flags, size_t startIndex, size_t endIndex);
 	void RandomizeAudiologs();
 	void SwapPanels(int panel1, int panel2, int flags);
+	void ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets = {});
+	void SwapWithRandomPanel(int panel1, const std::vector<int>& possiblePanels, int flags);
+	void ShuffleRange(std::vector<int>& order, size_t startIndex, size_t endIndex);
+	void ShufflePanels();
 
 	std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe");
+	std::set<int> _alreadySwapped;
+	std::map<int, int> _shuffleMapping;
 
 	friend class Panel;
 	friend class PuzzleList;

--- a/Source/Special.cpp
+++ b/Source/Special.cpp
@@ -1406,7 +1406,6 @@ void Special::createArrowPuzzle(int id, int x, int y, int dir, int ticks, const 
 		generator->set(p, p.first % 2 ? Decoration::Gap_Row : Decoration::Gap_Column);
 	}
 	generator->write(id);
-	(new ArrowWatchdog(id))->start();
 }
 
 void Special::createArrowSecretDoor(int id)
@@ -1423,7 +1422,6 @@ void Special::createArrowSecretDoor(int id)
 	generator->set(9, 5, Decoration::Arrow | (3 << 12) | (3 << 16));
 	generator->set(9, 9, Decoration::Arrow | (3 << 12) | (6 << 16));
 	generator->write(id);
-	(new ArrowWatchdog(id))->start();
 }
 
 void Special::generateCenterPerspective(int id, const std::vector<std::pair<int, int>>& symbolVec, int symbolType)


### PR DESCRIPTION
This change adds a feature that, when enabled, shuffles panels after generating them. This is similar to how players would previously run this randomizer and Darkid's at the same time. However, this feature makes it possible to do double randomizer on Expert, because it keeps track of the panels that the arrows have been shuffled to.

Arrow panels will not be shuffled onto glass panels because of an issue that prevents them from being rendered.