### PR TITLE
Fix Desert Panels swapping their lines around on rerando

### DIFF
--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -93,7 +93,7 @@ void Randomizer::RandomizeDesert() {
 			continue;
 		}
 		if (i != target) {
-			SwapPanels(puzzles[i], puzzles[target], SWAP::LINES);
+			SwapPanels(puzzles[i], puzzles[target], SWAP::PATHS);
 			std::swap(desertPanels[i], desertPanels[target]);
 		}
 		_memory->WritePanelData<float>(puzzles[i], PATH_WIDTH_SCALE, { 0.8f });
@@ -188,8 +188,7 @@ void Randomizer::SwapPanels(int panel1, int panel2, int flags) {
 		offsets[NUM_COLORED_REGIONS] = sizeof(int);
 		offsets[COLORED_REGIONS] = sizeof(void*);
 	}
-	if (flags & SWAP::LINES) {
-		offsets[TRACED_EDGES] = 16;
+	if (flags & SWAP::PATHS) {
 		offsets[AUDIO_PREFIX] = sizeof(void*);
 		offsets[PATH_WIDTH_SCALE] = sizeof(float);
 		offsets[STARTPOINT_SCALE] = sizeof(float);
@@ -215,6 +214,9 @@ void Randomizer::SwapPanels(int panel1, int panel2, int flags) {
 		offsets[DOT_SEQUENCE_REFLECTION] = sizeof(void*);
 		offsets[PANEL_TARGET] = sizeof(void*);
 		offsets[SPECULAR_TEXTURE] = sizeof(void*);
+	}
+	if (flags & SWAP::DRAWN_LINES) {
+		offsets[TRACED_EDGES] = 16;
 	}
 
 	for (auto const&[offset, size] : offsets) {
@@ -273,27 +275,27 @@ void Randomizer::ShufflePanels(bool hard) {
 
 	// General shuffles.
 	if (hard) {
-		SwapWithRandomPanel(0x0A3B5, tutorialBackLeftExpertOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
+		SwapWithRandomPanel(0x0A3B5, tutorialBackLeftExpertOptions, SWAP::PATHS | SWAP::COLORS); // Tutorial Back Left
 	} else {
-		SwapWithRandomPanel(0x0A3B5, tutorialBackLeftOptions, SWAP::LINES | SWAP::COLORS); // Tutorial Back Left
+		SwapWithRandomPanel(0x0A3B5, tutorialBackLeftOptions, SWAP::PATHS | SWAP::COLORS); // Tutorial Back Left
 	}
-	Randomize(utmElevatorControls, SWAP::LINES | SWAP::COLORS);
-	Randomize(treehousePivotSet, SWAP::LINES | SWAP::COLORS);
-	Randomize(utmPerspectiveSet, SWAP::LINES | SWAP::COLORS);
+	Randomize(utmElevatorControls, SWAP::PATHS | SWAP::COLORS);
+	Randomize(treehousePivotSet, SWAP::PATHS | SWAP::COLORS);
+	Randomize(utmPerspectiveSet, SWAP::PATHS | SWAP::COLORS);
 	if (!hard) {
-		Randomize(symmetryLaserYellows, SWAP::LINES | SWAP::COLORS);
-		Randomize(symmetryLaserBlues, SWAP::LINES | SWAP::COLORS);
-		Randomize(squarePanels, SWAP::LINES | SWAP::COLORS);
+		Randomize(symmetryLaserYellows, SWAP::PATHS | SWAP::COLORS);
+		Randomize(symmetryLaserBlues, SWAP::PATHS | SWAP::COLORS);
+		Randomize(squarePanels, SWAP::PATHS | SWAP::COLORS);
 	} else {
 		std::vector<int> panelsToRandom = copyWithoutElements(squarePanels, squarePanelsExpertBanned);
 		std::vector<int> firstPass = copyWithoutElements(panelsToRandom, arrowPanels);
 		std::vector<int> secondPass = copyWithoutElements(panelsToRandom, glassPanels);
 
-		Randomize(firstPass, SWAP::LINES | SWAP::COLORS);
-		Randomize(secondPass, SWAP::LINES | SWAP::COLORS);
+		Randomize(firstPass, SWAP::PATHS | SWAP::COLORS);
+		Randomize(secondPass, SWAP::PATHS | SWAP::COLORS);
 	}
-	Randomize(desertPanelsWide, SWAP::LINES);
-	Randomize(mountainMultipanel, SWAP::LINES | SWAP::COLORS);
+	Randomize(desertPanelsWide, SWAP::PATHS);
+	Randomize(mountainMultipanel, SWAP::PATHS | SWAP::COLORS);
 
 	// Symmetry transparent.
 	std::vector<int> transparentRandomOrder(transparent.size(), 0);

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -16,9 +16,10 @@ public:
 	enum SWAP {
 		NONE = 0,
 		TARGETS = 1,
-		LINES = 2,
+		PATHS = 2,
 		AUDIO_NAMES = 4,
 		COLORS = 8,
+		DRAWN_LINES = 16,
 	};
 
 	int seed = 0;


### PR DESCRIPTION
Also renaming "Swap::LINES" to "Swap::PATHS" to disambiguate it better from the new "Swap::DRAWN_LINES"