### PR TITLE
Remove blue squares on Mountain Rainbow 5

### DIFF
--- a/Source/PuzzleList.cpp
+++ b/Source/PuzzleList.cpp
@@ -2097,7 +2097,6 @@ void PuzzleList::GenerateMountainH()
 	generator->generate(0x09FD7, Decoration::Star | Decoration::Color::Yellow, 6, Decoration::Star | Decoration::Color::Green, 6,
 		Decoration::Star | Decoration::Color::Cyan, 6, Decoration::Star | Decoration::Color::Magenta, 6);
 	generator->setGridSize(5, 5);
-	generator->blockPos = { {1, 1}, {1, 5}, {3, 3}, {5, 3}, {5, 5}, {5, 7}, {7, 1}, {7, 5}, {7, 9}, {9, 1}, {9, 5}, {9, 9} };
 	generator->generate(0x09FD8, Decoration::Star | Decoration::Color::Green, 4, Decoration::Star | Decoration::Color::Magenta, 5,
 	Decoration::Poly | Decoration::Can_Rotate | Decoration::Color::Green, 1, Decoration::Poly | Decoration::Can_Rotate | Decoration::Color::Magenta, 1, Decoration::Eraser | Decoration::Color::Magenta, 1);
 	Memory::get()->LoadPackage("save_58472");

--- a/Source/PuzzleList.cpp
+++ b/Source/PuzzleList.cpp
@@ -785,6 +785,10 @@ void PuzzleList::GenerateMountainN()
 	generator->setSymbol(Decoration::Exit, 10, 10);
 	generator->setSymmetry(Panel::Symmetry::Rotational);
 	generator->generate(0x09FD8, Decoration::Dot_Intersection | Decoration::Color::Blue, 4, Decoration::Dot_Intersection | Decoration::Color::Orange, 4);
+	//Normally, we have to load a package before we can edit texture.
+	//But this texture is in same package as bunker textures, which happens before this
+	//its already loaded. There is no need to load it again
+	TextureLoader::get()->generateTexture(0x09FD8);
 	generator->resetConfig();
 
 	specialCase->generateMultiPuzzle({ 0x09FCC, 0x09FCE, 0x09FCF, 0x09FD0, 0x09FD1, 0x09FD2 }, {
@@ -2098,6 +2102,7 @@ void PuzzleList::GenerateMountainH()
 	generator->blockPos = { {1, 1}, {1, 5}, {3, 3}, {5, 3}, {5, 5}, {5, 7}, {7, 1}, {7, 5}, {7, 9}, {9, 1}, {9, 5}, {9, 9} };
 	generator->generate(0x09FD8, Decoration::Star | Decoration::Color::Green, 4, Decoration::Star | Decoration::Color::Magenta, 5,
 	Decoration::Poly | Decoration::Can_Rotate | Decoration::Color::Green, 1, Decoration::Poly | Decoration::Can_Rotate | Decoration::Color::Magenta, 1, Decoration::Eraser | Decoration::Color::Magenta, 1);
+	TextureLoader::get()->generateTexture(0x09FD8);
 	generator->resetConfig();
 
 	specialCase->generateMultiPuzzle({ 0x09FCC, 0x09FCE, 0x09FCF, 0x09FD0, 0x09FD1, 0x09FD2 }, {

--- a/Source/PuzzleList.cpp
+++ b/Source/PuzzleList.cpp
@@ -785,9 +785,7 @@ void PuzzleList::GenerateMountainN()
 	generator->setSymbol(Decoration::Exit, 10, 10);
 	generator->setSymmetry(Panel::Symmetry::Rotational);
 	generator->generate(0x09FD8, Decoration::Dot_Intersection | Decoration::Color::Blue, 4, Decoration::Dot_Intersection | Decoration::Color::Orange, 4);
-	//Normally, we have to load a package before we can edit texture.
-	//But this texture is in same package as bunker textures, which happens before this
-	//its already loaded. There is no need to load it again
+	Memory::get()->LoadPackage("save_58472");
 	TextureLoader::get()->generateTexture(0x09FD8);
 	generator->resetConfig();
 
@@ -2102,6 +2100,7 @@ void PuzzleList::GenerateMountainH()
 	generator->blockPos = { {1, 1}, {1, 5}, {3, 3}, {5, 3}, {5, 5}, {5, 7}, {7, 1}, {7, 5}, {7, 9}, {9, 1}, {9, 5}, {9, 9} };
 	generator->generate(0x09FD8, Decoration::Star | Decoration::Color::Green, 4, Decoration::Star | Decoration::Color::Magenta, 5,
 	Decoration::Poly | Decoration::Can_Rotate | Decoration::Color::Green, 1, Decoration::Poly | Decoration::Can_Rotate | Decoration::Color::Magenta, 1, Decoration::Eraser | Decoration::Color::Magenta, 1);
+	Memory::get()->LoadPackage("save_58472");
 	TextureLoader::get()->generateTexture(0x09FD8);
 	generator->resetConfig();
 

--- a/Source/TextureLoader.cpp
+++ b/Source/TextureLoader.cpp
@@ -110,6 +110,7 @@ TextureLoader* TextureLoader::get()
 void TextureLoader::forceLoadBunkerTextures() {
 	Memory* memory = Memory::get();
 	memory->LoadPackage("save_58472"); //tells game to load the color bunker assets into memory, so we can edit them
+	//this package *also* contains texture for Mountain Rainbow 5 which is convenient.
 }
 
 void TextureLoader::forceLoadDesertTextures() {
@@ -155,6 +156,17 @@ void TextureLoader::generateTexture(int32_t panelid)
 	case 0x17E67:
 	case 0x0A079:
 		generateColorBunkerTexture(panelid);
+		break;
+	case 0x09FD8: //mountain rainbow 5 just needs a solid white texture on it.
+		TextureMaker tm(512, 512);
+		auto wtxBuffer = tm.generate_blank_texture();
+		Memory* memory = Memory::get();
+
+		auto texturename = textureNames[panelid];
+		// corresponding package is always loaded. shared with bunker textures, which get preloaded before this does.
+		memory->LoadTexture(memory->GetTextureMapFromCatalog(texturename), wtxBuffer);
+		memory->WritePanelData(panelid, NEEDS_REDRAW, 1);
+		break;
 	}
 	
 }

--- a/Source/TextureLoader.h
+++ b/Source/TextureLoader.h
@@ -27,6 +27,12 @@ public:
 	void generateSpecTexture(int32_t panelid);
 };
 
+
+// map of panel ids->texture names.
+// there isn't always a 1:1 match. Some panels have multiple textures. (Town triple has 4 textures total that affect the puzzle)
+// desert panels don't use this list, they just grab SPECULAR_TEXTURE directly from the panel.
+// see the following doc if you need a texture name thats not on this list.
+// https://docs.google.com/spreadsheets/d/1sB6TIPzc-YMfQGDvOE3h-Tg8HitVkAwhnw_qoZkvbmE/edit?usp=sharing
 inline std::unordered_map<int32_t, std::string> textureNames = {
 	{0x09F7D, "obj_panels_color_tricolor_1"},
 	{0x09FDC, "obj_panels_color_tricolor_2"},
@@ -43,4 +49,5 @@ inline std::unordered_map<int32_t, std::string> textureNames = {
 	{0x17E63, "obj_panels_color_coloredlight_1"},
 	{0x17E67, "obj_panels_color_coloredlight_2"},
 	{0x0A079, "obj_panels_color_tricolorNew_Elevator"},
+	{0x09FD8, "cc_pretty_mask"}
 };

--- a/Source/TextureMaker.cpp
+++ b/Source/TextureMaker.cpp
@@ -289,6 +289,21 @@ void TextureMaker::flip_image_vertically(cairo_surface_t* image)
 }
 
 
+// blank white texture. patches blue squares on mountain rainbow 5
+std::vector<uint8_t> TextureMaker::generate_blank_texture() {
+	auto background = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
+	//flip_image_vertically(background); //doesn't *really* matter, but texture loads upside down to what game displays.
+
+	auto cr = cairo_create(background);
+	cairo_set_source_rgb(cr, 1.0, 1.0, 1.0);
+	cairo_paint(cr);
+	cairo_surface_flush(background);
+	auto finalTexture = convert_cairo_surface_to_wtx(background, 1, 0x00);
+	cairo_destroy(cr);
+	cairo_surface_destroy(background);
+	return finalTexture;
+}
+
 std::vector<uint8_t> TextureMaker::generate_color_panel_grid(std::vector<std::vector<int>> grid, int id, std::vector<Color> colors, bool specular)
 {
 	auto gridheight = grid.size();

--- a/Source/TextureMaker.h
+++ b/Source/TextureMaker.h
@@ -42,8 +42,10 @@ public:
 			return 0;
 		}
 	};
+	std::vector<uint8_t> generate_blank_texture();
 	std::vector<uint8_t> generate_color_panel_grid(std::vector<std::vector<int>> grid, int id, std::vector<Color> colors, bool specular = false);
 	std::vector<uint8_t> generate_desert_spec_line(std::vector<float> xpoints, std::vector<float> ypoints, float thickness, float dotthickness, bool symmetry);
+
 
 };
 


### PR DESCRIPTION
This one puzzle in mountain usually has blue squares when randomized.
This is an artifact of the original puzzle - there are usually colored squares there. There is a texture mask, leaving gaps in the shader where the original puzzle elements are, to reveal those elements through the rainbow shader. The blue squares are the puzzle's blue background being revealed, since we remove the original puzzle elements.

Replacing this mask with a solid white texture removes the blue squares.

Hypothetically I think we could place our own puzzle elements on this puzzle, and draw on the mask so that those elements display without the shader effect if we wanted to. But for now this is a simple change, and makes the puzzle less confusing. The blue squares have no effect on the puzzle anyway.

Edit: the blue squares technically slightly impact expert mode generation - as it avoids placing elements on those squares. With blue squares removed, we can remove that restriction. Other than visual clarity of the puzzle, i don't think this makes much of a change to its difficulty.

Before:
![image](https://github.com/user-attachments/assets/0e8b7cf8-d9c3-48ee-be46-d3463888f6bf)
After: 
![image](https://github.com/user-attachments/assets/be1a5529-28c0-45fd-8623-20315e2f41e8)

