### PR TITLE
Added Memory Speed Optimization

### DIFF
--- a/Source/Generate.cpp
+++ b/Source/Generate.cpp
@@ -222,6 +222,8 @@ void Generate::write(int id)
 
 	erase_path();
 
+	Memory* memory = Memory::get();
+
 	incrementProgress();
 
 	if (hasFlag(Config::ResetColors)) {
@@ -237,34 +239,34 @@ void Generate::write(int id)
 		_panel->colorMode = colorblind ? Panel::ColorMode::TreehouseAlternate : Panel::ColorMode::Treehouse;
 	}
 	if (hasFlag(Config::Write2Color)) {
-		Special::WritePanelData(id, PATTERN_POINT_COLOR_A, _panel->_memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_A));
-		Special::WritePanelData(id, PATTERN_POINT_COLOR_B, _panel->_memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_B));
-		Special::WritePanelData(id, REFLECTION_PATH_COLOR, _panel->_memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_B));
-		Special::WritePanelData(id, ACTIVE_COLOR, _panel->_memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_A));
+		memory->WritePanelData(id, PATTERN_POINT_COLOR_A, memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_A));
+		memory->WritePanelData(id, PATTERN_POINT_COLOR_B, memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_B));
+		memory->WritePanelData(id, REFLECTION_PATH_COLOR, memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_B));
+		memory->WritePanelData(id, ACTIVE_COLOR, memory->ReadPanelData<Color>(0x0007C, PATTERN_POINT_COLOR_A));
 	}
 	if (hasFlag(Config::WriteInvisible)) {
-		Special::WritePanelData(id, REFLECTION_PATH_COLOR, _panel->_memory->ReadPanelData<Color>(0x00076, REFLECTION_PATH_COLOR));
+		memory->WritePanelData(id, REFLECTION_PATH_COLOR, memory->ReadPanelData<Color>(0x00076, REFLECTION_PATH_COLOR));
 	}
 	if (hasFlag(Config::WriteDotColor))
-		Special::WritePanelData(id, PATTERN_POINT_COLOR, { 0.1f, 0.1f, 0.1f, 1 });
+		memory->WritePanelData<float>(id, PATTERN_POINT_COLOR, { 0.1f, 0.1f, 0.1f, 1 });
 	if (hasFlag(Config::WriteDotColor2)) {
-		Color color = _panel->_memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A);
-		Special::WritePanelData(id, PATTERN_POINT_COLOR, color);
+		Color color = memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A);
+		memory->WritePanelData(id, PATTERN_POINT_COLOR, color);
 	}
 	if (arrowColor.a > 0 || backgroundColor.a > 0 || successColor.a > 0) {
-		Special::WritePanelData(id, OUTER_BACKGROUND, { backgroundColor });
+		memory->WritePanelData<Color>(id, OUTER_BACKGROUND, { backgroundColor });
 		if (arrowColor.a == 0)
-			Special::WritePanelData(id, BACKGROUND_REGION_COLOR, { _panel->_memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A) });
-		Special::WritePanelData(id, BACKGROUND_REGION_COLOR, { arrowColor });
-		Special::WritePanelData(id, OUTER_BACKGROUND_MODE, 1);
-		if (successColor.a == 0) Special::WritePanelData(id, SUCCESS_COLOR_A, _panel->_memory->ReadPanelData<Color>(id, BACKGROUND_REGION_COLOR));
-		else Special::WritePanelData(id, SUCCESS_COLOR_A, successColor);
-		Special::WritePanelData(id, SUCCESS_COLOR_B, _panel->_memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A));
-		Special::WritePanelData(id, ACTIVE_COLOR, { 1, 1, 1, 1 });
-		Special::WritePanelData(id, REFLECTION_PATH_COLOR, { 1, 1, 1, 1 });
+			memory->WritePanelData<Color>(id, BACKGROUND_REGION_COLOR, { memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A) });
+		memory->WritePanelData<Color>(id, BACKGROUND_REGION_COLOR, { arrowColor });
+		memory->WritePanelData(id, OUTER_BACKGROUND_MODE, 1);
+		if (successColor.a == 0) memory->WritePanelData(id, SUCCESS_COLOR_A, memory->ReadPanelData<Color>(id, BACKGROUND_REGION_COLOR));
+		else memory->WritePanelData(id, SUCCESS_COLOR_A, successColor);
+		memory->WritePanelData<Color>(id, SUCCESS_COLOR_B, memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A));
+		memory->WritePanelData<float>(id, ACTIVE_COLOR, { 1, 1, 1, 1 });
+		memory->WritePanelData<float>(id, REFLECTION_PATH_COLOR, { 1, 1, 1, 1 });
 	}
 	if (hasFlag(Config::TreehouseLayout)) {
-		Special::WritePanelData(id, SPECULAR_ADD, 0.001f);
+		memory->WritePanelData(id, SPECULAR_ADD, 0.001f);
 	}
 
 	_panel->decorationsOnly = hasFlag(Config::DecorationsOnly);

--- a/Source/Panel.cpp
+++ b/Source/Panel.cpp
@@ -23,24 +23,23 @@ int find(const std::vector<T> &data, T search, size_t startIndex = 0) {
 }
 
 Panel::Panel() {
-	_memory = std::make_shared<Memory>("witness64_d3d11.exe");
 }
 
 Panel::Panel(int id) {
-	_memory = std::make_shared<Memory>("witness64_d3d11.exe");
 	Read(id);
 }
 
 void Panel::Read() {
-	_width = 2 * _memory->ReadPanelData<int>(id, GRID_SIZE_X) - 1;
-	if (_memory->ReadPanelData<int>(id, IS_CYLINDER)) {
+	Memory* memory = Memory::get();
+	_width = 2 * memory->ReadPanelData<int>(id, GRID_SIZE_X) - 1;
+	if (memory->ReadPanelData<int>(id, IS_CYLINDER)) {
 		_width++;
 		Point::pillarWidth = _width;
 	}
 	else Point::pillarWidth = 0;
-	_height = 2 * _memory->ReadPanelData<int>(id, GRID_SIZE_Y) - 1;
+	_height = 2 * memory->ReadPanelData<int>(id, GRID_SIZE_Y) - 1;
 	if (_width <= 0 || _height <= 0 || _width > 30 || _height > 30) {
-		int numIntersections = _memory->ReadPanelData<int>(id, NUM_DOTS);
+		int numIntersections = memory->ReadPanelData<int>(id, NUM_DOTS);
 		_width = _height = static_cast<int>(std::round(sqrt(numIntersections))) * 2 - 1;
 	}
 	_grid.resize(_width);
@@ -53,7 +52,7 @@ void Panel::Read() {
 	_startpoints.clear();
 	_endpoints.clear();
 
-	_style = _memory->ReadPanelData<int>(id, STYLE_FLAGS);
+	_style = memory->ReadPanelData<int>(id, STYLE_FLAGS);
 	ReadAllData();
 	ReadIntersections();
 	ReadDecorations();
@@ -65,18 +64,20 @@ void Panel::Read() {
 }
 
 void Panel::Write() {
-	_memory->WritePanelData<int>(id, GRID_SIZE_X, { (_width + 1) / 2 });
-	_memory->WritePanelData<int>(id, GRID_SIZE_Y, { (_height + 1) / 2 });
-	if (_resized && _memory->ReadPanelData<int>(id, NUM_COLORED_REGIONS) > 0) {
+	Memory* memory = Memory::get();
+
+	memory->WritePanelData<int>(id, GRID_SIZE_X, { (_width + 1) / 2 });
+	memory->WritePanelData<int>(id, GRID_SIZE_Y, { (_height + 1) / 2 });
+	if (_resized && memory->ReadPanelData<int>(id, NUM_COLORED_REGIONS) > 0) {
 		//Make two triangles that cover the whole panel
 		std::vector<int> newRegions = { 0, xy_to_loc(_width - 1, 0), xy_to_loc(0, 0), 0, xy_to_loc(_width - 1, _height - 1), xy_to_loc(_width - 1, 0), 0, 0 };
-		_memory->WritePanelData<int>(id, NUM_COLORED_REGIONS, { static_cast<int>(newRegions.size()) / 4 });
-		_memory->WriteArray(id, COLORED_REGIONS, newRegions);
+		memory->WritePanelData<int>(id, NUM_COLORED_REGIONS, { static_cast<int>(newRegions.size()) / 4 });
+		memory->WriteArray(id, COLORED_REGIONS, newRegions);
 	}
 
 	if (!decorationsOnly) WriteIntersections();
 	else {
-		std::vector<int> iflags = _memory->ReadArray<int>(id, DOT_FLAGS, _memory->ReadPanelData<int>(id, NUM_DOTS));
+		std::vector<int> iflags = memory->ReadArray<int>(id, DOT_FLAGS, memory->ReadPanelData<int>(id, NUM_DOTS));
 		for (int x = 0; x < _width; x += 2) {
 			for (int y = 0; y < _height; y += 2) {
 				if (_grid[x][y] & Decoration::Dot) {
@@ -85,13 +86,13 @@ void Panel::Write() {
 				}
 			}
 		}
-		_memory->WriteArray<int>(id, DOT_FLAGS, iflags);
+		memory->WriteArray<int>(id, DOT_FLAGS, iflags);
 	}
 	WriteDecorations();
 	if (enableFlash) _style &= ~NO_BLINK;
-	_memory->WritePanelData<int>(id, STYLE_FLAGS, { _style });
-	if (pathWidth != 1) _memory->WritePanelData<float>(id, PATH_WIDTH_SCALE, { pathWidth });
-	_memory->WritePanelData<int>(id, NEEDS_REDRAW, { 1 });
+	memory->WritePanelData<int>(id, STYLE_FLAGS, { _style });
+	if (pathWidth != 1) memory->WritePanelData<float>(id, PATH_WIDTH_SCALE, { pathWidth });
+	memory->WritePanelData<int>(id, NEEDS_REDRAW, { 1 });
 	generatedPanels.push_back(*this);
 }
 
@@ -189,70 +190,77 @@ void Panel::Resize(int width, int height)
 	_resized = true;
 }
 
+Color Panel::GetBackgroundColor() {
+	return Memory::get()->ReadPanelData<Color>(0x0008F, BACKGROUND_REGION_COLOR);
+}
+
+
 void Panel::ReadAllData() {
-	Color pathColor = _memory->ReadPanelData<Color>(id, PATH_COLOR);
-	Color rpathColor = _memory->ReadPanelData<Color>(id, REFLECTION_PATH_COLOR);
-	Color successColor = _memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A);
-	Color strobeColor = _memory->ReadPanelData<Color>(id, STROBE_COLOR_A);
-	Color errorColor = _memory->ReadPanelData<Color>(id, ERROR_COLOR);
-	int numDecorations = _memory->ReadPanelData<int>(id, NUM_DECORATIONS);
-	Color a = _memory->ReadPanelData<Color>(id, SYMBOL_A);
-	Color b = _memory->ReadPanelData<Color>(id, SYMBOL_B);
-	Color c = _memory->ReadPanelData<Color>(id, SYMBOL_C);
-	Color d = _memory->ReadPanelData<Color>(id, SYMBOL_D);
-	Color e = _memory->ReadPanelData<Color>(id, SYMBOL_E);
-	Color ppColor = _memory->ReadPanelData<Color>(id, PATTERN_POINT_COLOR);
-	Color ppColorA = _memory->ReadPanelData<Color>(id, PATTERN_POINT_COLOR_A);
-	Color ppColorB = _memory->ReadPanelData<Color>(id, PATTERN_POINT_COLOR_B);
-	int pushSymbolColors = _memory->ReadPanelData<int>(id, PUSH_SYMBOL_COLORS);
-	int numColored = _memory->ReadPanelData<int>(id, NUM_COLORED_REGIONS);
-	std::vector<int> colored = _memory->ReadArray<int>(id, COLORED_REGIONS, numColored * 4);
-	int numConnections = _memory->ReadPanelData<int>(id, NUM_CONNECTIONS);
-	int numDots = _memory->ReadPanelData<int>(id, NUM_DOTS);
-	int reflectionData = _memory->ReadPanelData<int>(id, REFLECTION_DATA);
-	std::vector<int> rdata; if (reflectionData) rdata = _memory->ReadArray<int>(id, REFLECTION_DATA, numDots);
-	int style = _memory->ReadPanelData<int>(id, STYLE_FLAGS);
-	std::vector<int> connections_a = _memory->ReadArray<int>(id, DOT_CONNECTION_A, numConnections);
-	std::vector<int> connections_b = _memory->ReadArray<int>(id, DOT_CONNECTION_B, numConnections);
-	int numIntersections = _memory->ReadPanelData<int>(id, NUM_DOTS);
-	std::vector<float> intersections = _memory->ReadArray<float>(id, DOT_POSITIONS, numIntersections * 2);
-	std::vector<int> intersectionFlags = _memory->ReadArray<int>(id, DOT_FLAGS, numIntersections);
-	std::vector<int> decorations = _memory->ReadArray<int>(id, DECORATIONS, numDecorations);
-	std::vector<int> decorationFlags = _memory->ReadArray<int>(id, DECORATION_FLAGS, numDecorations);
-	float width = _memory->ReadPanelData<float>(id, PATH_WIDTH_SCALE);
-	int seqLen = _memory->ReadPanelData<int>(id, SEQUENCE_LEN);
-	std::vector<int> seq = _memory->ReadArray<int>(id, SEQUENCE, seqLen);
-	std::vector<float> power = _memory->ReadPanelData<float>(id, POWER, 2);
-	float openRate = _memory->ReadPanelData<float>(id, OPEN_RATE);
-	int cptr = _memory->ReadPanelData<int>(id, DECORATION_COLORS);
-	std::vector<Color> colors; if (cptr) colors = _memory->ReadArray<Color>(id, DECORATION_COLORS, numDecorations);
-	Color outerBackground = _memory->ReadPanelData<Color>(id, OUTER_BACKGROUND);
-	int outerBackgroundMode = _memory->ReadPanelData<int>(id, OUTER_BACKGROUND_MODE);
-	Color bgRegionColor = _memory->ReadPanelData<Color>(id, BACKGROUND_REGION_COLOR);
-	short metadata = _memory->ReadPanelData<short>(id, METADATA);
-	//void* specularTexture = _memory->ReadPanelData<void*>(id, SPECULAR_TEXTURE);
-	//std::vector<float> data = _memory->ReadPanelData<float>(id, SPECULAR_TEXTURE, 1000);
-	int dotSeqLen = _memory->ReadPanelData<int>(id, DOT_SEQUENCE_LEN);
-	std::vector<int> dotSeq = _memory->ReadArray<int>(id, DOT_SEQUENCE, dotSeqLen);
-	int dotSeqLenR = _memory->ReadPanelData<int>(id, DOT_SEQUENCE_LEN_REFLECTION);
-	std::vector<int> dotSeqR = _memory->ReadArray<int>(id, DOT_SEQUENCE_REFLECTION, dotSeqLenR);
-	void* target = _memory->ReadPanelData<void*>(id, TARGET);
-	void* panelTarget = _memory->ReadPanelData<void*>(id, PANEL_TARGET);
-	Color cableTarget = _memory->ReadPanelData<Color>(id, CABLE_TARGET_2);
-	//std::vector<int> targets = _memory->ReadArray<int>(id, PANEL_TARGET, 6);
-	int isPillar = _memory->ReadPanelData<int>(id, IS_CYLINDER);
-	int numTraced = _memory->ReadPanelData<int>(id, TRACED_EDGES);
-	int numSol = _memory->ReadPanelData<int>(id, TRACED_EDGES + 4); //Don't know what this number is for yet
-	int tracedptr = _memory->ReadPanelData<int>(id, TRACED_EDGE_DATA);
-	//float solved = _memory->ReadPanelData<float>(id, PANEL_SOLVED);
-	float distance = _memory->ReadPanelData<float>(id, MAX_BROADCAST_DISTANCE);
-	std::vector<SolutionPoint> traced; if (tracedptr) traced = _memory->ReadArray<SolutionPoint>(id, TRACED_EDGE_DATA, numTraced);
+	Memory* memory = Memory::get();
+	Color pathColor = memory->ReadPanelData<Color>(id, PATH_COLOR);
+	Color rpathColor = memory->ReadPanelData<Color>(id, REFLECTION_PATH_COLOR);
+	Color successColor = memory->ReadPanelData<Color>(id, SUCCESS_COLOR_A);
+	Color strobeColor = memory->ReadPanelData<Color>(id, STROBE_COLOR_A);
+	Color errorColor = memory->ReadPanelData<Color>(id, ERROR_COLOR);
+	int numDecorations = memory->ReadPanelData<int>(id, NUM_DECORATIONS);
+	Color a = memory->ReadPanelData<Color>(id, SYMBOL_A);
+	Color b = memory->ReadPanelData<Color>(id, SYMBOL_B);
+	Color c = memory->ReadPanelData<Color>(id, SYMBOL_C);
+	Color d = memory->ReadPanelData<Color>(id, SYMBOL_D);
+	Color e = memory->ReadPanelData<Color>(id, SYMBOL_E);
+	Color ppColor = memory->ReadPanelData<Color>(id, PATTERN_POINT_COLOR);
+	Color ppColorA = memory->ReadPanelData<Color>(id, PATTERN_POINT_COLOR_A);
+	Color ppColorB = memory->ReadPanelData<Color>(id, PATTERN_POINT_COLOR_B);
+	int pushSymbolColors = memory->ReadPanelData<int>(id, PUSH_SYMBOL_COLORS);
+	int numColored = memory->ReadPanelData<int>(id, NUM_COLORED_REGIONS);
+	std::vector<int> colored = memory->ReadArray<int>(id, COLORED_REGIONS, numColored * 4);
+	int numConnections = memory->ReadPanelData<int>(id, NUM_CONNECTIONS);
+	int numDots = memory->ReadPanelData<int>(id, NUM_DOTS);
+	int reflectionData = memory->ReadPanelData<int>(id, REFLECTION_DATA);
+	std::vector<int> rdata; if (reflectionData) rdata = memory->ReadArray<int>(id, REFLECTION_DATA, numDots);
+	int style = memory->ReadPanelData<int>(id, STYLE_FLAGS);
+	std::vector<int> connections_a = memory->ReadArray<int>(id, DOT_CONNECTION_A, numConnections);
+	std::vector<int> connections_b = memory->ReadArray<int>(id, DOT_CONNECTION_B, numConnections);
+	int numIntersections = memory->ReadPanelData<int>(id, NUM_DOTS);
+	std::vector<float> intersections = memory->ReadArray<float>(id, DOT_POSITIONS, numIntersections * 2);
+	std::vector<int> intersectionFlags = memory->ReadArray<int>(id, DOT_FLAGS, numIntersections);
+	std::vector<int> decorations = memory->ReadArray<int>(id, DECORATIONS, numDecorations);
+	std::vector<int> decorationFlags = memory->ReadArray<int>(id, DECORATION_FLAGS, numDecorations);
+	float width = memory->ReadPanelData<float>(id, PATH_WIDTH_SCALE);
+	int seqLen = memory->ReadPanelData<int>(id, SEQUENCE_LEN);
+	std::vector<int> seq = memory->ReadArray<int>(id, SEQUENCE, seqLen);
+	std::vector<float> power = memory->ReadPanelData<float>(id, POWER, 2);
+	float openRate = memory->ReadPanelData<float>(id, OPEN_RATE);
+	int cptr = memory->ReadPanelData<int>(id, DECORATION_COLORS);
+	std::vector<Color> colors; if (cptr) colors = memory->ReadArray<Color>(id, DECORATION_COLORS, numDecorations);
+	Color outerBackground = memory->ReadPanelData<Color>(id, OUTER_BACKGROUND);
+	int outerBackgroundMode = memory->ReadPanelData<int>(id, OUTER_BACKGROUND_MODE);
+	Color bgRegionColor = memory->ReadPanelData<Color>(id, BACKGROUND_REGION_COLOR);
+	short metadata = memory->ReadPanelData<short>(id, METADATA);
+	//void* specularTexture = memory->ReadPanelData<void*>(id, SPECULAR_TEXTURE);
+	//std::vector<float> data = memory->ReadPanelData<float>(id, SPECULAR_TEXTURE, 1000);
+	int dotSeqLen = memory->ReadPanelData<int>(id, DOT_SEQUENCE_LEN);
+	std::vector<int> dotSeq = memory->ReadArray<int>(id, DOT_SEQUENCE, dotSeqLen);
+	int dotSeqLenR = memory->ReadPanelData<int>(id, DOT_SEQUENCE_LEN_REFLECTION);
+	std::vector<int> dotSeqR = memory->ReadArray<int>(id, DOT_SEQUENCE_REFLECTION, dotSeqLenR);
+	void* target = memory->ReadPanelData<void*>(id, TARGET);
+	void* panelTarget = memory->ReadPanelData<void*>(id, PANEL_TARGET);
+	Color cableTarget = memory->ReadPanelData<Color>(id, CABLE_TARGET_2);
+	//std::vector<int> targets = memory->ReadArray<int>(id, PANEL_TARGET, 6);
+	int isPillar = memory->ReadPanelData<int>(id, IS_CYLINDER);
+	int numTraced = memory->ReadPanelData<int>(id, TRACED_EDGES);
+	int numSol = memory->ReadPanelData<int>(id, TRACED_EDGES + 4); //Don't know what this number is for yet
+	int tracedptr = memory->ReadPanelData<int>(id, TRACED_EDGE_DATA);
+	//float solved = memory->ReadPanelData<float>(id, PANEL_SOLVED);
+	float distance = memory->ReadPanelData<float>(id, MAX_BROADCAST_DISTANCE);
+	std::vector<SolutionPoint> traced; if (tracedptr) traced = memory->ReadArray<SolutionPoint>(id, TRACED_EDGE_DATA, numTraced);
 }
 
 void Panel::ReadDecorations() {
-	int numDecorations = _memory->ReadPanelData<int>(id, NUM_DECORATIONS);
-	std::vector<int> decorations = _memory->ReadArray<int>(id, DECORATIONS, numDecorations);
-	std::vector<int> decorationFlags = _memory->ReadArray<int>(id, DECORATION_FLAGS, numDecorations);
+	Memory* memory = Memory::get();
+	int numDecorations = memory->ReadPanelData<int>(id, NUM_DECORATIONS);
+	std::vector<int> decorations = memory->ReadArray<int>(id, DECORATIONS, numDecorations);
+	std::vector<int> decorationFlags = memory->ReadArray<int>(id, DECORATION_FLAGS, numDecorations);
 
 	for (int i=0; i<numDecorations; i++) {
 		auto [x, y] = dloc_to_xy(i);
@@ -261,6 +269,7 @@ void Panel::ReadDecorations() {
 }
 
 void Panel::WriteDecorations() {
+	Memory* memory = Memory::get();
 	std::vector<int> decorations;
 	std::vector<Color> decorationColors;
 	bool any = false;
@@ -298,39 +307,39 @@ void Panel::WriteDecorations() {
 		for (int i = 0; i < decorations.size(); i++) {
 			if (decorations[i] == 0) decorations[i] = Decoration::Triangle; //To force it to be unsolvable
 		}
-		_memory->WritePanelData<int>(id, OUTER_BACKGROUND_MODE, { 1 });
+		memory->WritePanelData<int>(id, OUTER_BACKGROUND_MODE, { 1 });
 	}
 	if (!any) {
-		_memory->WritePanelData<int>(id, NUM_DECORATIONS, { 0 });
+		memory->WritePanelData<int>(id, NUM_DECORATIONS, { 0 });
 	}
 	else {
-		_memory->WritePanelData<int>(id, NUM_DECORATIONS, { static_cast<int>(decorations.size()) });
-		if (colorMode == ColorMode::WriteColors || colorMode == ColorMode::Treehouse || colorMode == ColorMode::TreehouseAlternate || _memory->ReadPanelData<int>(id, DECORATION_COLORS))
-			_memory->WriteArray<Color>(id, DECORATION_COLORS, decorationColors);
+		memory->WritePanelData<int>(id, NUM_DECORATIONS, { static_cast<int>(decorations.size()) });
+		if (colorMode == ColorMode::WriteColors || colorMode == ColorMode::Treehouse || colorMode == ColorMode::TreehouseAlternate || memory->ReadPanelData<int>(id, DECORATION_COLORS))
+			memory->WriteArray<Color>(id, DECORATION_COLORS, decorationColors);
 		else if (colorMode == ColorMode::Reset || colorMode == ColorMode::Alternate) {
-			_memory->WritePanelData<int>(id, PUSH_SYMBOL_COLORS, { colorMode == ColorMode::Reset ? 0 : 1 });
+			memory->WritePanelData<int>(id, PUSH_SYMBOL_COLORS, { colorMode == ColorMode::Reset ? 0 : 1 });
 		}
 		if (colorMode == ColorMode::Treehouse) {
-			_memory->WritePanelData<int>(id, PUSH_SYMBOL_COLORS, { 1 });
-			_memory->WritePanelData<Color>(id, SYMBOL_A, { { 0, 0, 0, 1 } }); //Black
-			_memory->WritePanelData<Color>(id, SYMBOL_B, { { 1, 1, 1, 1 } }); //White
-			_memory->WritePanelData<Color>(id, SYMBOL_C, { { 1, 0.5, 0, 1 } }); //Orange
-			_memory->WritePanelData<Color>(id, SYMBOL_D, { { 1, 0, 1, 1 } }); //Magenta
-			_memory->WritePanelData<Color>(id, SYMBOL_E, { { 0, 1, 0, 1 } }); //Green
+			memory->WritePanelData<int>(id, PUSH_SYMBOL_COLORS, { 1 });
+			memory->WritePanelData<Color>(id, SYMBOL_A, { { 0, 0, 0, 1 } }); //Black
+			memory->WritePanelData<Color>(id, SYMBOL_B, { { 1, 1, 1, 1 } }); //White
+			memory->WritePanelData<Color>(id, SYMBOL_C, { { 1, 0.5, 0, 1 } }); //Orange
+			memory->WritePanelData<Color>(id, SYMBOL_D, { { 1, 0, 1, 1 } }); //Magenta
+			memory->WritePanelData<Color>(id, SYMBOL_E, { { 0, 1, 0, 1 } }); //Green
 		}
 		else if (colorMode == ColorMode::TreehouseAlternate) {
-			_memory->WritePanelData<int>(id, PUSH_SYMBOL_COLORS, { 1 });
-			_memory->WritePanelData<Color>(id, SYMBOL_A, { { 0, 0, 0, 1 } }); //Black
-			_memory->WritePanelData<Color>(id, SYMBOL_B, { { 0, 0, 1, 1 } }); //White->Blue
-			_memory->WritePanelData<Color>(id, SYMBOL_C, { { 1, 0.5, 0, 1 } }); //Orange
-			_memory->WritePanelData<Color>(id, SYMBOL_D, { { 1, 0, 1, 1 } }); //Magenta
-			_memory->WritePanelData<Color>(id, SYMBOL_E, { { 1, 1, 1, 1 } }); //Green->White
+			memory->WritePanelData<int>(id, PUSH_SYMBOL_COLORS, { 1 });
+			memory->WritePanelData<Color>(id, SYMBOL_A, { { 0, 0, 0, 1 } }); //Black
+			memory->WritePanelData<Color>(id, SYMBOL_B, { { 0, 0, 1, 1 } }); //White->Blue
+			memory->WritePanelData<Color>(id, SYMBOL_C, { { 1, 0.5, 0, 1 } }); //Orange
+			memory->WritePanelData<Color>(id, SYMBOL_D, { { 1, 0, 1, 1 } }); //Magenta
+			memory->WritePanelData<Color>(id, SYMBOL_E, { { 1, 1, 1, 1 } }); //Green->White
 		}
 	}
-	if (any || _memory->ReadPanelData<int>(id, DECORATIONS)) {
-		_memory->WriteArray<int>(id, DECORATIONS, decorations);
+	if (any || memory->ReadPanelData<int>(id, DECORATIONS)) {
+		memory->WriteArray<int>(id, DECORATIONS, decorations);
 		for (int i = 0; i < decorations.size(); i++) decorations[i] = 0;
-		_memory->WriteArray<int>(id, DECORATION_FLAGS, decorations);
+		memory->WriteArray<int>(id, DECORATION_FLAGS, decorations);
 	}
 	if (arrows) {
 		arrowPuzzles.emplace_back(id, Point::pillarWidth);
@@ -352,8 +361,9 @@ void Panel::StartArrowWatchdogs(const std::map<int, int>& shuffleMappings) {
 }
 
 void Panel::ReadIntersections() {
-	int numIntersections = _memory->ReadPanelData<int>(id, NUM_DOTS);
-	std::vector<float> intersections = _memory->ReadArray<float>(id, DOT_POSITIONS, numIntersections * 2);
+	Memory* memory = Memory::get();
+	int numIntersections = memory->ReadPanelData<int>(id, NUM_DOTS);
+	std::vector<float> intersections = memory->ReadArray<float>(id, DOT_POSITIONS, numIntersections * 2);
 	int num_grid_points = this->get_num_grid_points();
 	minx = intersections[0]; miny = intersections[1];
 	maxx = intersections[num_grid_points * 2 - 2]; maxy = intersections[num_grid_points * 2 - 1];
@@ -362,9 +372,9 @@ void Panel::ReadIntersections() {
 	unitWidth = (maxx - minx) / (_width - 1);
 	if (Point::pillarWidth) unitWidth = 1.0f / _width;
 	unitHeight = (maxy - miny) / (_height - 1);
-	std::vector<int> intersectionFlags = _memory->ReadArray<int>(id, DOT_FLAGS, numIntersections);
-	std::vector<int> symmetryData = _memory->ReadPanelData<int>(id, REFLECTION_DATA) ? 
-		_memory->ReadArray<int>(id, REFLECTION_DATA, numIntersections) : std::vector<int>();
+	std::vector<int> intersectionFlags = memory->ReadArray<int>(id, DOT_FLAGS, numIntersections);
+	std::vector<int> symmetryData = memory->ReadPanelData<int>(id, REFLECTION_DATA) ? 
+		memory->ReadArray<int>(id, REFLECTION_DATA, numIntersections) : std::vector<int>();
 	if (symmetryData.size() == 0) symmetry = Symmetry::None;
 	else if (symmetryData[0] == num_grid_points - 1) symmetry = Symmetry::Rotational;
 	else if (symmetryData[0] == _width / 2 && intersections[1] == intersections[3]) symmetry = Symmetry::Vertical;
@@ -385,9 +395,9 @@ void Panel::ReadIntersections() {
 			_grid[x][y] = OPEN;
 		}
 	}
-	int numConnections = _memory->ReadPanelData<int>(id, NUM_CONNECTIONS);
-	std::vector<int> connections_a = _memory->ReadArray<int>(id, DOT_CONNECTION_A, numConnections);
-	std::vector<int> connections_b = _memory->ReadArray<int>(id, DOT_CONNECTION_B, numConnections);
+	int numConnections = memory->ReadPanelData<int>(id, NUM_CONNECTIONS);
+	std::vector<int> connections_a = memory->ReadArray<int>(id, DOT_CONNECTION_A, numConnections);
+	std::vector<int> connections_b = memory->ReadArray<int>(id, DOT_CONNECTION_B, numConnections);
 	//Remove non-existent connections
 	std::vector<std::string> out;
 	for (int i = 0; i < connections_a.size(); i++) {
@@ -464,6 +474,8 @@ void Panel::ReadIntersections() {
 }
 
 void Panel::WriteIntersections() {
+	Memory* memory = Memory::get();
+
 	std::vector<float> intersections;
 	std::vector<int> intersectionFlags;
 	std::vector<int> connections_a;
@@ -628,26 +640,26 @@ void Panel::WriteIntersections() {
 	//Symmetry Data
 	if (id == 0x01D3F && symmetry == Symmetry::None || id == 0x00076 && symmetry == Symmetry::None) {
 		_style &= ~Style::SYMMETRICAL;
-		_memory->WritePanelData<long long>(id, REFLECTION_DATA, { 0 });
+		memory->WritePanelData<long long>(id, REFLECTION_DATA, { 0 });
 	}
 	else if (symmetryData.size() > 0) {
 		_style |= Style::SYMMETRICAL;
-		_memory->WriteArray<int>(id, REFLECTION_DATA, symmetryData);
+		memory->WriteArray<int>(id, REFLECTION_DATA, symmetryData);
 	}
 	else {
 		_style &= ~Style::SYMMETRICAL;
-		_memory->WritePanelData<long long>(id, REFLECTION_DATA, { 0 });
+		memory->WritePanelData<long long>(id, REFLECTION_DATA, { 0 });
 	}
 
-	_memory->WritePanelData<int>(id, NUM_DOTS, { static_cast<int>(intersectionFlags.size()) });
-	_memory->WriteArray<float>(id, DOT_POSITIONS, intersections);
-	_memory->WriteArray<int>(id, DOT_FLAGS, intersectionFlags);
-	_memory->WritePanelData<int>(id, NUM_CONNECTIONS, { static_cast<int>(connections_a.size()) });
-	_memory->WriteArray<int>(id, DOT_CONNECTION_A, connections_a);
-	_memory->WriteArray<int>(id, DOT_CONNECTION_B, connections_b);
+	memory->WritePanelData<int>(id, NUM_DOTS, { static_cast<int>(intersectionFlags.size()) });
+	memory->WriteArray<float>(id, DOT_POSITIONS, intersections);
+	memory->WriteArray<int>(id, DOT_FLAGS, intersectionFlags);
+	memory->WritePanelData<int>(id, NUM_CONNECTIONS, { static_cast<int>(connections_a.size()) });
+	memory->WriteArray<int>(id, DOT_CONNECTION_A, connections_a);
+	memory->WriteArray<int>(id, DOT_CONNECTION_B, connections_b);
 	
 	if (polygons.size() > 0) {
-		_memory->WritePanelData<int>(id, NUM_COLORED_REGIONS, { static_cast<int>(polygons.size()) / 4 });
-		_memory->WriteArray<int>(id, COLORED_REGIONS, polygons);
+		memory->WritePanelData<int>(id, NUM_COLORED_REGIONS, { static_cast<int>(polygons.size()) / 4 });
+		memory->WriteArray<int>(id, COLORED_REGIONS, polygons);
 	}
 }

--- a/Source/Panel.h
+++ b/Source/Panel.h
@@ -1,8 +1,9 @@
 #pragma once
-#include "Memory.h"
-#include "Randomizer.h"
+
+#include <map>
 #include <stdint.h>
 #include <tuple>
+#include <functional>
 
 struct Point {
 	int first;
@@ -149,6 +150,8 @@ public:
 	void ClearGridSymbol(int x, int y);
 	void Resize(int width, int height);
 
+	Color GetBackgroundColor();
+
 	static void StartArrowWatchdogs(const std::map<int, int>& shuffleMappings = {});
 
 	enum Style {
@@ -212,7 +215,7 @@ private:
 	Point get_sym_point(Point p) { return get_sym_point(p.first, p.second, symmetry); }
 	Point get_sym_point(Point p, Symmetry symmetry) { return get_sym_point(p.first, p.second, symmetry); }
 	Endpoint::Direction get_sym_dir(Endpoint::Direction direction, Symmetry symmetry) {
-		int dirIndex;
+		int dirIndex = -1;
 		if (direction == Endpoint::Direction::LEFT) dirIndex = 0;
 		if (direction == Endpoint::Direction::RIGHT) dirIndex = 1;
 		if (direction == Endpoint::Direction::UP) dirIndex = 2;
@@ -260,7 +263,6 @@ private:
 			default: return { 0, 0, 0, 0 };
 			}
 		}
-		Color xcolor;
 		switch (color) {
 		case Decoration::Color::Black: return { 0, 0, 0, 1 };
 		case Decoration::Color::White: return { 1, 1, 1, 1 };
@@ -272,10 +274,11 @@ private:
 		case Decoration::Color::Yellow: return { 1, 1, 0, 1 };
 		case Decoration::Color::Orange: return { 1, 0.5, 0, 1 };
 		case Decoration::Color::Purple: return { 0.5, 0, 1, 1 };
-		case Decoration::Color::X: //Copy background color
-			xcolor = _memory->ReadPanelData<Color>(0x0008F, BACKGROUND_REGION_COLOR);
-			xcolor.a = 1;
-			return xcolor;
+		case Decoration::Color::X: { //Copy background color
+			Color xColor = GetBackgroundColor();
+			xColor.a = 1;
+			return xColor;
+		}
 		default: return { 0, 0, 0, 0 };
 		}
 	}
@@ -421,8 +424,6 @@ private:
 			polygons.push_back(polys[i] + baseIndex);
 		}
 	}
-
-	std::shared_ptr<Memory> _memory;
 
 	int _width, _height;
 

--- a/Source/PuzzleList.cpp
+++ b/Source/PuzzleList.cpp
@@ -208,6 +208,7 @@ void PuzzleList::GenerateSymmetryN()
 
 void PuzzleList::GenerateQuarryN()
 {
+	Memory* memory = Memory::get();
 	generator->setLoadingData(L"Quarry", 39);
 	generator->resetConfig();
 	//Entry Gates
@@ -264,14 +265,14 @@ void PuzzleList::GenerateQuarryN()
 	//Eraser + Shapes
 	generator->setFlag(Generate::Config::ResetColors);
 	generator->generate(0x021B3, Decoration::Poly, 3, Decoration::Eraser | Decoration::Color::White, 1);
-	specialCase->WritePanelData(0x021B4, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021B4, POWER_OFF_ON_FAIL, 0);
 	generator->generate(0x021B4, Decoration::Poly, 3, Decoration::Eraser | Decoration::Color::White, 1);
-	specialCase->WritePanelData(0x021B0, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021B0, POWER_OFF_ON_FAIL, 0);
 	generator->generate(0x021B0, Decoration::Poly, 4, Decoration::Eraser | Decoration::Color::White, 1);
-	specialCase->WritePanelData(0x021AF, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021AF, POWER_OFF_ON_FAIL, 0);
 	generator->setFlagOnce(Generate::Config::SmallShapes);
 	generator->generate(0x021AF, Decoration::Poly, 4, Decoration::Eraser | Decoration::Color::White, 1);
-	specialCase->WritePanelData(0x021AE, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021AE, POWER_OFF_ON_FAIL, 0);
 	generator->setFlagOnce(Generate::Config::DisconnectShapes);
 	generator->generate(0x021AE, Decoration::Poly, 3, Decoration::Eraser | Decoration::Color::White, 1);
 	generator->removeFlag(Generate::Config::ResetColors);
@@ -1203,6 +1204,7 @@ void PuzzleList::GenerateSymmetryH()
 
 void PuzzleList::GenerateQuarryH()
 {
+	Memory* memory = Memory::get();
 	generator->setLoadingData(L"Quarry", 40);
 	generator->resetConfig();
 	//Entry Gates
@@ -1280,15 +1282,15 @@ void PuzzleList::GenerateQuarryH()
 	//Eraser + Shapes
 	generator->setFlag(Generate::Config::ResetColors);
 	generator->generate(0x021B3, Decoration::Poly, 3, Decoration::Poly | Decoration::Negative, 1, Decoration::Eraser | Decoration::Color::White, 1);
-	specialCase->WritePanelData(0x021B4, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021B4, POWER_OFF_ON_FAIL, 0);
 	generator->generate(0x021B4, Decoration::Poly, 3, Decoration::Poly | Decoration::Negative, 1, Decoration::Eraser | Decoration::Color::White, 1);
-	specialCase->WritePanelData(0x021B0, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021B0, POWER_OFF_ON_FAIL, 0);
 	generator->generate(0x021B0, Decoration::Poly, 4, Decoration::Poly | Decoration::Negative, 1, Decoration::Eraser | Decoration::Color::White, 1);
-	specialCase->WritePanelData(0x021AF, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021AF, POWER_OFF_ON_FAIL, 0);
 	generator->setGridSize(4, 4);
 	generator->generate(0x021AF, Decoration::Poly, 3, Decoration::Poly | Decoration::Negative, 2, Decoration::Eraser | Decoration::Color::White, 1);
 	generator->setFlagOnce(Generate::Config::DisconnectShapes);
-	specialCase->WritePanelData(0x021AE, POWER_OFF_ON_FAIL, 0);
+	memory->WritePanelData(0x021AE, POWER_OFF_ON_FAIL, 0);
 	generator->generate(0x021AE, Decoration::Poly, 3, Decoration::Poly | Decoration::Negative, 1, Decoration::Eraser | Decoration::Color::White, 1);
 	generator->resetConfig();
 	//Eraser + Stars
@@ -2193,7 +2195,7 @@ void PuzzleList::GenerateCavesH()
 		Decoration::Eraser | Decoration::Color::Cyan, 1);
 	//Arrow Pillar
 	generator->resetConfig();
-	specialCase->WritePanelData(0x09DD5, PATH_COLOR, { 0.01f, 0, 0.02f, 1 });
+	Memory::get()->WritePanelData <float>(0x09DD5, PATH_COLOR, { 0.01f, 0, 0.02f, 1 });
 	generator->backgroundColor = { 0, 0, 0, 1 };
 	generator->arrowColor = { 0.6f, 0, 1, 1 };
 	generator->successColor = { 1, 1, 1, 1 };

--- a/Source/Randomizer.cpp
+++ b/Source/Randomizer.cpp
@@ -59,18 +59,19 @@ int find(const std::vector<T> &data, T search, size_t startIndex = 0) {
 }
 
 void Randomizer::AdjustSpeed() {
-	_memory->WritePanelData<float>(0x09F95, OPEN_RATE, { 0.04f });  // Desert Surface Final Control, 4x
-	_memory->WritePanelData<float>(0x03839, OPEN_RATE, { 0.7f }); // Mill Ramp, 3x
-	_memory->WritePanelData<float>(0x021BA, OPEN_RATE, { 1.5f }); // Mill Lift, 3x
-	_memory->WritePanelData<float>(0x17CC1, OPEN_RATE, { 0.8f }); // Mill Elevator, 4x
-	_memory->WritePanelData<float>(0x0061A, OPEN_RATE, { 0.1f }); // Swamp Sliding Bridge, 4x
-	_memory->WritePanelData<float>(0x09EEC, OPEN_RATE, { 0.1f }); // Mountain 2 Elevator, 4x
-	_memory->WritePanelData<float>(0x17E74, OPEN_RATE, { 0.03f }); // Swamp Flood gate (inner), 2x //Keeping these slower for now to help with EP's
-	_memory->WritePanelData<float>(0x1802C, OPEN_RATE, { 0.03f }); // Swamp Flood gate (outer), 2x
-	_memory->WritePanelData<float>(0x005A2, OPEN_RATE, { 0.04f }); // Swamp Rotating Bridge, 4x
-	_memory->WritePanelData<float>(0x17C6A, OPEN_RATE, { 0.25f }); // Ramp Angle, 5x
-	_memory->WritePanelData<float>(0x17F02, OPEN_RATE, { 0.15f }); // Ramp Position, 4x
-	_memory->WritePanelData<float>(0x17C50, OPEN_RATE, { 0.3f }); //Boathouse Barrier, 2x
+	Memory* memory = Memory::get();
+	memory->WritePanelData<float>(0x09F95, OPEN_RATE, { 0.04f });  // Desert Surface Final Control, 4x
+	memory->WritePanelData<float>(0x03839, OPEN_RATE, { 0.7f }); // Mill Ramp, 3x
+	memory->WritePanelData<float>(0x021BA, OPEN_RATE, { 1.5f }); // Mill Lift, 3x
+	memory->WritePanelData<float>(0x17CC1, OPEN_RATE, { 0.8f }); // Mill Elevator, 4x
+	memory->WritePanelData<float>(0x0061A, OPEN_RATE, { 0.1f }); // Swamp Sliding Bridge, 4x
+	memory->WritePanelData<float>(0x09EEC, OPEN_RATE, { 0.1f }); // Mountain 2 Elevator, 4x
+	memory->WritePanelData<float>(0x17E74, OPEN_RATE, { 0.03f }); // Swamp Flood gate (inner), 2x //Keeping these slower for now to help with EP's
+	memory->WritePanelData<float>(0x1802C, OPEN_RATE, { 0.03f }); // Swamp Flood gate (outer), 2x
+	memory->WritePanelData<float>(0x005A2, OPEN_RATE, { 0.04f }); // Swamp Rotating Bridge, 4x
+	memory->WritePanelData<float>(0x17C6A, OPEN_RATE, { 0.25f }); // Ramp Angle, 5x
+	memory->WritePanelData<float>(0x17F02, OPEN_RATE, { 0.15f }); // Ramp Position, 4x
+	memory->WritePanelData<float>(0x17C50, OPEN_RATE, { 0.3f }); //Boathouse Barrier, 2x
 }
 
 void Randomizer::RandomizeDesert() {
@@ -96,7 +97,7 @@ void Randomizer::RandomizeDesert() {
 			SwapPanels(puzzles[i], puzzles[target], SWAP::PATHS);
 			std::swap(desertPanels[i], desertPanels[target]);
 		}
-		_memory->WritePanelData<float>(puzzles[i], PATH_WIDTH_SCALE, { 0.8f });
+		Memory::get()->WritePanelData<float>(puzzles[i], PATH_WIDTH_SCALE, { 0.8f });
 	}
 	/* TODO: Add into v1.3 after doing more experimentation
 	if (_memory->ReadPanelData<float>(0x00295, POWER) < 1)
@@ -219,23 +220,27 @@ void Randomizer::SwapPanels(int panel1, int panel2, int flags) {
 		offsets[TRACED_EDGES] = 16;
 	}
 
+	Memory* memory = Memory::get();
 	for (auto const&[offset, size] : offsets) {
-		std::vector<byte> panel1data = _memory->ReadPanelData<byte>(panel1, offset, size);
-		std::vector<byte> panel2data = _memory->ReadPanelData<byte>(panel2, offset, size);
-		_memory->WritePanelData<byte>(panel2, offset, panel1data);
-		_memory->WritePanelData<byte>(panel1, offset, panel2data);
+		std::vector<byte> panel1data = memory->ReadPanelData<byte>(panel1, offset, size);
+		std::vector<byte> panel2data = memory->ReadPanelData<byte>(panel2, offset, size);
+		memory->WritePanelData<byte>(panel2, offset, panel1data);
+		memory->WritePanelData<byte>(panel1, offset, panel2data);
 	}
-	_memory->WritePanelData<int>(panel1, NEEDS_REDRAW, { 1 });
-	_memory->WritePanelData<int>(panel2, NEEDS_REDRAW, { 1 });
+	memory->WritePanelData<int>(panel1, NEEDS_REDRAW, { 1 });
+	memory->WritePanelData<int>(panel2, NEEDS_REDRAW, { 1 });
+
+	memory->invalidateCache();
 }
 
 void Randomizer::ReassignTargets(const std::vector<int>& panels, const std::vector<int>& order, std::vector<int> targets) {
+	Memory* memory = Memory::get();
 	if (targets.empty()) {
 		// This list is offset by 1, so the target of the Nth panel is in position N (aka the N+1th element)
 		// The first panel may not have a wire to power it, so we use the panel ID itself.
 		targets = { panels[0] + 1 };
 		for (const int panel : panels) {
-			int target = _memory->ReadPanelData<int>(panel, TARGET, 1)[0];
+			int target = memory->ReadPanelData<int>(panel, TARGET, 1)[0];
 			targets.push_back(target);
 		}
 	}
@@ -243,7 +248,7 @@ void Randomizer::ReassignTargets(const std::vector<int>& panels, const std::vect
 	for (size_t i = 0; i < order.size() - 1; i++) {
 		// Set the target of order[i] to order[i+1], using the "real" target as determined above.
 		const int panelTarget = targets[order[i + 1]];
-		_memory->WritePanelData<int>(panels[order[i]], TARGET, { panelTarget });
+		memory->WritePanelData<int>(panels[order[i]], TARGET, { panelTarget });
 	}
 }
 
@@ -271,6 +276,7 @@ void Randomizer::ShuffleRange(std::vector<int>& order, size_t startIndex, size_t
 }
 
 void Randomizer::ShufflePanels(bool hard) {
+	Memory* memory = Memory::get();
 	_alreadySwapped.clear();
 
 	// General shuffles.
@@ -316,7 +322,7 @@ void Randomizer::ShufflePanels(bool hard) {
 
 	// Don't power off Town Apple Tree on fail on Expert.
 	if (hard) {
-		_memory->WritePanelData<int>(0x28938, POWER_OFF_ON_FAIL, { 0 });
+		memory->WritePanelData<int>(0x28938, POWER_OFF_ON_FAIL, { 0 });
 	}
 
 	// Monastery.
@@ -346,7 +352,7 @@ void Randomizer::ShufflePanels(bool hard) {
 	// Randomize final pillars order
 	std::vector<int> pillarTargets = { pillars[0] + 1 };
 	for (const int pillar : pillars) {
-		int target = _memory->ReadPanelData<int>(pillar, TARGET, 1)[0];
+		int target = memory->ReadPanelData<int>(pillar, TARGET, 1)[0];
 		pillarTargets.push_back(target);
 	}
 	pillarTargets[5] = pillars[5] + 1;
@@ -356,9 +362,9 @@ void Randomizer::ShufflePanels(bool hard) {
 	ShuffleRange(pillarRandomOrder, 5, 9); // Right Pillars 1-4
 	ReassignTargets(pillars, pillarRandomOrder, pillarTargets);
 	// Turn off original starting panels
-	_memory->WritePanelData<float>(pillars[0], POWER, { 0.0f, 0.0f });
-	_memory->WritePanelData<float>(pillars[5], POWER, { 0.0f, 0.0f });
+	memory->WritePanelData<float>(pillars[0], POWER, { 0.0f, 0.0f });
+	memory->WritePanelData<float>(pillars[5], POWER, { 0.0f, 0.0f });
 	// Turn on new starting panels
-	_memory->WritePanelData<float>(pillars[pillarRandomOrder[0]], POWER, { 1.0f, 1.0f });
-	_memory->WritePanelData<float>(pillars[pillarRandomOrder[5]], POWER, { 1.0f, 1.0f });
+	memory->WritePanelData<float>(pillars[pillarRandomOrder[0]], POWER, { 1.0f, 1.0f });
+	memory->WritePanelData<float>(pillars[pillarRandomOrder[5]], POWER, { 1.0f, 1.0f });
 }

--- a/Source/Randomizer.h
+++ b/Source/Randomizer.h
@@ -1,8 +1,10 @@
 #pragma once
-#include "Memory.h"
+
 #include <memory>
 #include <set>
 #include <map>
+#include <vector>
+#include <windows.h>
 
 class Randomizer {
 public:
@@ -10,8 +12,6 @@ public:
 	void GenerateHard(HWND loadingHandle);
 
 	void AdjustSpeed();
-
-	void ClearOffsets() {_memory->ClearOffsets();}
 
 	enum SWAP {
 		NONE = 0,
@@ -39,7 +39,6 @@ private:
 	void ShuffleRange(std::vector<int>& order, size_t startIndex, size_t endIndex);
 	void ShufflePanels(bool hard);
 
-	std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe");
 	std::set<int> _alreadySwapped;
 	std::map<int, int> _shuffleMapping;
 

--- a/Source/Special.h
+++ b/Source/Special.h
@@ -1,9 +1,8 @@
 #pragma once
 #include "Generate.h"
-#include "Randomizer.h"
-#include "Watchdog.h"
 #include <algorithm>
-#include "Random.h"
+#include "Memory.h"
+#include "Panel.h"
 
 typedef std::set<Point> Shape;
 
@@ -69,89 +68,57 @@ public:
 
 	static void setTarget(int puzzle, int target)
 	{
-		WritePanelData(puzzle, TARGET, target + 1);
+		Memory* memory = Memory::get();
+		memory->WritePanelData(puzzle, TARGET, target + 1);
 	}
 
 	static void clearTarget(int puzzle)
 	{
-		WritePanelData(puzzle, TARGET, 0);
+		Memory* memory = Memory::get();
+		memory->WritePanelData(puzzle, TARGET, 0);
 	}
 
 	static void copyTarget(int puzzle, int sourceTarget)
 	{
-		WritePanelData(puzzle, TARGET, ReadPanelData<int>(sourceTarget, TARGET));
+		Memory* memory = Memory::get();
+		memory->WritePanelData(puzzle, TARGET, memory->ReadPanelData<int>(sourceTarget, TARGET));
 	}
 	static bool hasBeenPlayed() {
-		return Special::ReadPanelData<float>(0x00295, POWER) > 0 || Special::ReadPanelData<int>(0x00064, TRACED_EDGES) > 0;
+		Memory* memory = Memory::get();	
+		return memory->ReadPanelData<float>(0x00295, POWER) > 0 || memory->ReadPanelData<int>(0x00064, TRACED_EDGES) > 0;
 	}
-	static bool hasBeenRandomized() {
-		return Special::ReadPanelData<int>(0x00064, BACKGROUND_REGION_COLOR + 12) > 0;
+	static bool hasBeenRandomized() { 
+		Memory* memory = Memory::get();
+		return memory->ReadPanelData<int>(0x00064, BACKGROUND_REGION_COLOR + 12) > 0;
 	}
 	static void setTargetAndDeactivate(int puzzle, int target)
 	{
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe");
+		Memory* memory = Memory::get();
 		if (!hasBeenRandomized()) //Only deactivate on a fresh save file (since power state is preserved)
-			_memory->WritePanelData<float>(target, POWER, { 0.0, 0.0 });
-		WritePanelData(puzzle, TARGET, target + 1);
+			memory->WritePanelData<float>(target, POWER, { 0.0, 0.0 });
+		memory->WritePanelData(puzzle, TARGET, target + 1);
 	}
 	static void setPower(int puzzle, bool power) {
-
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe");
+		Memory* memory = Memory::get();
 		if (!power && hasBeenRandomized()) return; //Only deactivate on a fresh save file (since power state is preserved)
-		if (power) _memory->WritePanelData<float>(puzzle, POWER, { 1.0, 1.0 });
-		else _memory->WritePanelData<float>(puzzle, POWER, { 0.0, 0.0 });
-	}
-	template <class T> static std::vector<T> ReadPanelData(int panel, int offset, size_t size) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->ReadPanelData<T>(panel, offset, size);
-	}
-	template <class T> T static ReadPanelData(int panel, int offset) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->ReadPanelData<T>(panel, offset);
-	}
-	template <class T> static std::vector<T> ReadArray(int panel, int offset, int size) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->ReadArray<T>(panel, offset, size);
-	}
-	static void WritePanelData(int panel, int offset, int data) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->WritePanelData<int>(panel, offset, { data });
-	}
-	static void WritePanelData(int panel, int offset, float data) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->WritePanelData<float>(panel, offset, { data });
-	}
-	static void WritePanelData(int panel, int offset, Color data) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->WritePanelData<Color>(panel, offset, { data });
-	}
-	static void WriteArray(int panel, int offset, const std::vector<int>& data) {
-		return WriteArray(panel, offset, data, false);
-	}
-	static void WriteArray(int panel, int offset, const std::vector<int>& data, bool force) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->WriteArray<int>(panel, offset, data, force);
-	}
-	static void WriteArray(int panel, int offset, const std::vector<float>& data) {
-		return WriteArray(panel, offset, data, false);
-	}
-	static void WriteArray(int panel, int offset, const std::vector<float>& data, bool force) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->WriteArray<float>(panel, offset, data, force);
-	}
-	static void WriteArray(int panel, int offset, const std::vector<Color>& data) {
-		return WriteArray(panel, offset, data, false);
-	}
-	static void WriteArray(int panel, int offset, const std::vector<Color>& data, bool force) {
-		std::shared_ptr<Memory> _memory = std::make_shared<Memory>("witness64_d3d11.exe"); return _memory->WriteArray<Color>(panel, offset, data, force);
+		if (power) memory->WritePanelData<float>(puzzle, POWER, { 1.0, 1.0 });
+		else memory->WritePanelData<float>(puzzle, POWER, { 0.0, 0.0 });
 	}
 
 	static void testSwap(int id1, int id2) {
-		std::shared_ptr<Panel> panel = std::make_shared<Panel>();
-		std::vector<byte> bytes1 = panel->_memory->ReadPanelData<byte>(id1, 0, 0x600);
-		std::vector<byte> bytes2 = panel->_memory->ReadPanelData<byte>(id2, 0, 0x600);
-		panel->_memory->WritePanelData<byte>(id1, TRACED_EDGES, bytes2);
-		panel->_memory->WritePanelData<byte>(id2, TRACED_EDGES, bytes1);
-		panel->_memory->WritePanelData<int>(id1, NEEDS_REDRAW, { 1 });
-		panel->_memory->WritePanelData<int>(id2, NEEDS_REDRAW, { 1 });
+		Memory* memory = Memory::get();
+		std::vector<byte> bytes1 = memory->ReadPanelData<byte>(id1, 0, 0x600);
+		std::vector<byte> bytes2 = memory->ReadPanelData<byte>(id2, 0, 0x600);
+		memory->WritePanelData<byte>(id1, TRACED_EDGES, bytes2);
+		memory->WritePanelData<byte>(id2, TRACED_EDGES, bytes1);
+		memory->WritePanelData<int>(id1, NEEDS_REDRAW, { 1 });
+		memory->WritePanelData<int>(id2, NEEDS_REDRAW, { 1 });
 	}
 
 	template <class T> static std::vector<T> testRead(int address, int numItems) {
-		Memory memory("witness64_d3d11.exe");
+		Memory* memory = Memory::get();
 		std::vector<int> offsets = { address };
-		return memory.ReadData<T>(offsets, numItems);
+		return memory->ReadData<T>(offsets, numItems);
 	}
 
 	static void testPanel(int id) {
@@ -160,7 +127,7 @@ public:
 	}
 
 	template <class T> static uintptr_t testFind(uintptr_t startAddress, int length, T item) {
-		Memory memory("witness64_d3d11.exe");
+		Memory* memory = Memory::get(); 
 		uintptr_t address;
 		std::vector<byte> bytes;
 		bytes.resize(1024, 0);
@@ -168,7 +135,7 @@ public:
 		itemb.resize(sizeof(T));
 		std::memcpy(&itemb[0], &item, sizeof(T));
 		for (address = startAddress; address < startAddress + length; address += 1024) {
-			if (!memory.Read(reinterpret_cast<LPCVOID>(address), &bytes[0], 1024))
+			if (!memory->Read(reinterpret_cast<LPCVOID>(address), &bytes[0], 1024))
 				continue;
 			for (int i = 0; i < bytes.size() - itemb.size(); i += sizeof(T)) {
 				if (std::equal(bytes.begin() + i, bytes.begin() + i + sizeof(T), itemb.begin()))
@@ -179,7 +146,6 @@ public:
 	}
 
 	template <class T> static uintptr_t testFind2(uintptr_t startAddress, int length, T item) {
-		Memory memory("witness64_d3d11.exe");
 		uintptr_t address;
 		std::vector<byte> bytes;
 		bytes.resize(1024, 0);
@@ -187,7 +153,7 @@ public:
 		itemb.resize(sizeof(T) - 1);
 		std::memcpy(&itemb[0], &item, sizeof(T) - 1);
 		for (address = startAddress; address < startAddress + length; address += 1024) {
-			if (!memory.Read(reinterpret_cast<LPCVOID>(address), &bytes[0], 1024))
+			if (!Memory::get()->Read(reinterpret_cast<LPCVOID>(address), &bytes[0], 1024))
 				continue;
 			for (int i = 0; i < bytes.size() - itemb.size() + 1; i += sizeof(T)) {
 				if (std::equal(bytes.begin() + i, bytes.begin() + i + sizeof(T) - 1, itemb.begin()))

--- a/Source/Watchdog.cpp
+++ b/Source/Watchdog.cpp
@@ -5,6 +5,8 @@
 #include "Watchdog.h"
 #include "Quaternion.h"
 #include <thread>
+#include "Panel.h"
+#include "Randomizer.h"
 
 void Watchdog::start()
 {
@@ -34,6 +36,26 @@ void KeepWatchdog::action() {
 }
 
 //Arrow Watchdog - To run the arrow puzzles
+
+ArrowWatchdog::ArrowWatchdog(int id) : Watchdog(0.1f) {
+	Panel panel(id);
+	this->id = id;
+	grid = backupGrid = panel._grid;
+	width = static_cast<int>(grid.size());
+	height = static_cast<int>(grid[0].size());
+	pillarWidth = tracedLength = 0;
+	complete = false;
+	style = ReadPanelData<int>(id, STYLE_FLAGS);
+	DIRECTIONS = { Point(0, 2), Point(0, -2), Point(2, 0), Point(-2, 0), Point(2, 2), Point(2, -2), Point(-2, -2), Point(-2, 2) };
+	exitPos = panel.xy_to_loc(panel._endpoints[0].GetX(), panel._endpoints[0].GetY());
+	exitPosSym = (width / 2 + 1) * (height / 2 + 1) - 1 - exitPos;
+	exitPoint = (width / 2 + 1) * (height / 2 + 1);
+}
+
+ArrowWatchdog::ArrowWatchdog(int id, int pillarWidth) : ArrowWatchdog(id) {
+	this->pillarWidth = pillarWidth;
+	if (pillarWidth > 0) exitPoint = (width / 2) * (height / 2 + 1);
+}
 
 void ArrowWatchdog::action() {
 	int length = ReadPanelData<int>(id, TRACED_EDGES);
@@ -173,19 +195,20 @@ bool ArrowWatchdog::checkArrowPillar(int x, int y)
 
 void BridgeWatchdog::action()
 {
-	int length1 = _memory->ReadPanelData<int>(id1, TRACED_EDGES);
-	int length2 = _memory->ReadPanelData<int>(id2, TRACED_EDGES);
+	Memory* memory = Memory::get();
+	int length1 = memory->ReadPanelData<int>(id1, TRACED_EDGES);
+	int length2 = memory->ReadPanelData<int>(id2, TRACED_EDGES);
 	if (solLength1 > 0 && length1 == 0) {
-		_memory->WritePanelData<int>(id2, STYLE_FLAGS, { _memory->ReadPanelData<int>(id2, STYLE_FLAGS) | Panel::Style::HAS_DOTS });
+		memory->WritePanelData<int>(id2, STYLE_FLAGS, { memory->ReadPanelData<int>(id2, STYLE_FLAGS) | Panel::Style::HAS_DOTS });
 	}
 	if (solLength2 > 0 && length2 == 0) {
-		_memory->WritePanelData<int>(id1, STYLE_FLAGS, { _memory->ReadPanelData<int>(id1, STYLE_FLAGS) | Panel::Style::HAS_DOTS });
+		memory->WritePanelData<int>(id1, STYLE_FLAGS, { memory->ReadPanelData<int>(id1, STYLE_FLAGS) | Panel::Style::HAS_DOTS });
 	}
 	if (length1 != solLength1 && length1 > 0 && !checkTouch(id2)) {
-		_memory->WritePanelData<int>(id2, STYLE_FLAGS, { _memory->ReadPanelData<int>(id2, STYLE_FLAGS) & ~Panel::Style::HAS_DOTS });
+		memory->WritePanelData<int>(id2, STYLE_FLAGS, { memory->ReadPanelData<int>(id2, STYLE_FLAGS) & ~Panel::Style::HAS_DOTS });
 	}
 	if (length2 != solLength2 && length2 > 0 && !checkTouch(id1)) {
-		_memory->WritePanelData<int>(id1, STYLE_FLAGS, { _memory->ReadPanelData<int>(id1, STYLE_FLAGS) & ~Panel::Style::HAS_DOTS });
+		memory->WritePanelData<int>(id1, STYLE_FLAGS, { memory->ReadPanelData<int>(id1, STYLE_FLAGS) & ~Panel::Style::HAS_DOTS });
 	}
 	solLength1 = length1;
 	solLength2 = length2;
@@ -193,11 +216,12 @@ void BridgeWatchdog::action()
 
 bool BridgeWatchdog::checkTouch(int id)
 {
-	int length = _memory->ReadPanelData<int>(id, TRACED_EDGES);
+	Memory* memory = Memory::get();
+	int length = memory->ReadPanelData<int>(id, TRACED_EDGES);
 	if (length == 0) return false;
-	int numIntersections = _memory->ReadPanelData<int>(id, NUM_DOTS);
-	std::vector<int> intersectionFlags = _memory->ReadArray<int>(id, DOT_FLAGS, numIntersections);
-	std::vector<SolutionPoint> edges = _memory->ReadArray<SolutionPoint>(id, TRACED_EDGE_DATA, length);
+	int numIntersections = memory->ReadPanelData<int>(id, NUM_DOTS);
+	std::vector<int> intersectionFlags = memory->ReadArray<int>(id, DOT_FLAGS, numIntersections);
+	std::vector<SolutionPoint> edges = memory->ReadArray<SolutionPoint>(id, TRACED_EDGE_DATA, length);
 	for (const SolutionPoint& sp : edges) if (intersectionFlags[sp.pointA] == Decoration::Dot_Intersection || intersectionFlags[sp.pointB] == Decoration::Dot_Intersection) return true;
 	return false;
 }
@@ -209,6 +233,20 @@ void TreehouseWatchdog::action()
 		WritePanelData<int>(0x17DAE, NEEDS_REDRAW, { 1 });
 		terminate = true;
 	}
+}
+
+// Jungle watchdog
+
+JungleWatchdog::JungleWatchdog(int id, std::vector<int> correctSeq1, std::vector<int> correctSeq2) : Watchdog(0.5f) {
+	this->id = id;
+	int size = ReadPanelData<int>(id, NUM_DOTS);
+	sizes = ReadArray<int>(id, DOT_FLAGS, ReadPanelData<int>(id, NUM_DOTS));
+	this->correctSeq1 = correctSeq1;
+	this->correctSeq2 = correctSeq2;
+	state = false;
+	tracedLength = 0;
+	ptr1 = ReadPanelData<long>(id, DOT_SEQUENCE);
+	ptr2 = ReadPanelData<long>(id, DOT_SEQUENCE_REFLECTION);
 }
 
 void JungleWatchdog::action()

--- a/Source/Watchdog.h
+++ b/Source/Watchdog.h
@@ -1,8 +1,7 @@
 #pragma once
-#include "Memory.h"
-#include "Panel.h"
 #include "Randomizer.h"
 #include "Generate.h"
+#include "Memory.h"
 
 class Watchdog
 {
@@ -10,7 +9,6 @@ public:
 	Watchdog(float time) {
 		terminate = false;
 		sleepTime = time;
-		_memory = std::make_shared<Memory>("witness64_d3d11.exe");
 	};
 	void start();
 	void run();
@@ -19,24 +17,23 @@ public:
 	bool terminate;
 protected:
 	template <class T> std::vector<T> ReadPanelData(int panel, int offset, size_t size) {
-		return _memory->ReadPanelData<T>(panel, offset, size);
+		return Memory::get()->ReadPanelData<T>(panel, offset, size);
 	}
 	template <class T> T ReadPanelData(int panel, int offset) {
-		return _memory->ReadPanelData<T>(panel, offset);
+		return Memory::get()->ReadPanelData<T>(panel, offset);
 	}
 	template <class T> std::vector<T> ReadArray(int panel, int offset, int size) {
-		return _memory->ReadArray<T>(panel, offset, size);
+		return Memory::get()->ReadArray<T>(panel, offset, size);
 	}
 	template <class T> void WritePanelData(int panel, int offset, const std::vector<T>& data) {
-		return _memory->WritePanelData<T>(panel, offset, data);
+		return Memory::get()->WritePanelData<T>(panel, offset, data);
 	}
 	template <class T> void WriteArray(int panel, int offset, const std::vector<T>& data) {
-		return _memory->WriteArray<T>(panel, offset, data, false);
+		return Memory::get()->WriteArray<T>(panel, offset, data, false);
 	}
 	template <class T> void WriteArray(int panel, int offset, const std::vector<T>& data, bool force) {
-		return _memory->WriteArray<T>(panel, offset, data, force);
+		return Memory::get()->WriteArray<T>(panel, offset, data, force);
 	}
-	std::shared_ptr<Memory> _memory;
 };
 
 class KeepWatchdog : public Watchdog {
@@ -47,24 +44,8 @@ public:
 
 class ArrowWatchdog : public Watchdog {
 public:
-	ArrowWatchdog(int id) : Watchdog(0.1f) {
-		Panel panel(id);
-		this->id = id;
-		grid = backupGrid = panel._grid;
-		width = static_cast<int>(grid.size());
-		height = static_cast<int>(grid[0].size());
-		pillarWidth = tracedLength = 0;
-		complete = false;
-		style = ReadPanelData<int>(id, STYLE_FLAGS);
-		DIRECTIONS = { Point(0, 2), Point(0, -2), Point(2, 0), Point(-2, 0), Point(2, 2), Point(2, -2), Point(-2, -2), Point(-2, 2) };
-		exitPos = panel.xy_to_loc(panel._endpoints[0].GetX(), panel._endpoints[0].GetY());
-		exitPosSym = (width / 2 + 1) * (height / 2 + 1) - 1 - exitPos;
-		exitPoint = (width / 2 + 1) * (height / 2 + 1);
-	}
-	ArrowWatchdog(int id, int pillarWidth) : ArrowWatchdog(id) {
-		this->pillarWidth = pillarWidth;
-		if (pillarWidth > 0) exitPoint = (width / 2) * (height / 2 + 1);
-	}
+	ArrowWatchdog(int id);
+	ArrowWatchdog(int id, int pillarWidth);
 	virtual void action();
 	void initPath();
 	bool checkArrow(int x, int y);
@@ -78,7 +59,7 @@ public:
 	bool complete;
 	int style;
 	int exitPos, exitPosSym, exitPoint;
-	std::vector<Point> DIRECTIONS;
+	std::vector<struct Point> DIRECTIONS;
 };
 
 class BridgeWatchdog : public Watchdog {
@@ -101,17 +82,7 @@ public:
 
 class JungleWatchdog : public Watchdog {
 public:
-	JungleWatchdog(int id, std::vector<int> correctSeq1, std::vector<int> correctSeq2) : Watchdog(0.5f) {
-		this->id = id;
-		int size = ReadPanelData<int>(id, NUM_DOTS);
-		sizes = ReadArray<int>(id, DOT_FLAGS, ReadPanelData<int>(id, NUM_DOTS));
-		this->correctSeq1 = correctSeq1;
-		this->correctSeq2 = correctSeq2;
-		state = false;
-		tracedLength = 0;
-		ptr1 = ReadPanelData<long>(id, DOT_SEQUENCE);
-		ptr2 = ReadPanelData<long>(id, DOT_SEQUENCE_REFLECTION);
-	}
+	JungleWatchdog(int id, std::vector<int> correctSeq1, std::vector<int> correctSeq2);
 	virtual void action();
 	int id;
 	std::vector<int> sizes;


### PR DESCRIPTION
This replicate the memory improvement done by Blastron for Archipelago for it to work with standalone randomizer.
(see https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/commit/663f7c1fd88459715d2e640608126d36aacd8ff5)

The main idea is to have one Memory item which handles all the call instead of having multiple per panels and such.