### PR TITLE
Added proper support for symbols with disjoint components

### DIFF
--- a/Source/SymbolData.cpp
+++ b/Source/SymbolData.cpp
@@ -56,38 +56,45 @@ std::vector<float> SymbolData::GenerateData() {
 	constexpr int TRIANGLES_PER_SYMBOL = 42;
 	constexpr int VERTICES_PER_SYMBOL = 44;
 
-	std::array<Shape, NUM_SYMBOLS> allShapes = GetAllShapes();
+	std::array<std::vector<Shape>, NUM_SYMBOLS> allShapes = GetAllShapes();
 
 	std::vector<float> data(allShapes.size() * FLOATS_PER_SYMBOL, 0.0f);
 	for (int i = 0; i < NUM_SYMBOLS; i++) {
-		assert(allShapes[i].size() <= VERTICES_PER_SYMBOL); // Shape was bigger than the allowed size
+		size_t size = 0;
+		size_t indiceSize = 0;
+		int dataIndex = 0;
+		for (int j = 0; j < allShapes[i].size(); j++) {
+			size += allShapes[i][j].size();
+			assert(size <= VERTICES_PER_SYMBOL); // Shape was bigger than the allowed size
 
-		// Use the earcut library to divide the polygon into triangles.
-		// This returns an ordered list of points in the shape which comprise the triangles.
-		std::vector<uint32_t> indices = mapbox::earcut<uint32_t>(std::vector<Shape>{ allShapes[i] });
-		assert(indices.size() <= POINTS_PER_SYMBOL); // earcut somehow resulted in too many points
+			// Use the earcut library to divide the polygon into triangles.
+			// This returns an ordered list of points in the shape which comprise the triangles.
+			std::vector<uint32_t> indices = mapbox::earcut<uint32_t>(std::vector<Shape>{ allShapes[i][j] });
+			indiceSize += indices.size();
+			assert(indiceSize <= POINTS_PER_SYMBOL); // earcut somehow resulted in too many points
 
-		// Insert the triangulated polygon into the data array, and cast down to floats for the game
-		for (int j = 0; j < indices.size(); j++) {
-			data[i * FLOATS_PER_SYMBOL + j * 2]     = (float)allShapes[i][indices[j]][0]; // x coordinate
-			data[i * FLOATS_PER_SYMBOL + j * 2 + 1] = (float)allShapes[i][indices[j]][1]; // y coordinate
+			// Insert the triangulated polygon into the data array, and cast down to floats for the game
+			for (int k = 0; k < indices.size(); k++) {
+				data[i * FLOATS_PER_SYMBOL + (dataIndex) * 2]     = (float)allShapes[i][j][indices[k]][0]; // x coordinate
+				data[i * FLOATS_PER_SYMBOL + (dataIndex) * 2 + 1] = (float)allShapes[i][j][indices[k]][1]; // y coordinate
+				dataIndex++;
+			}
 		}
 	}
-
 	return data;
 }
 
-std::array<SymbolData::Shape, SymbolId::NUM_SYMBOLS> SymbolData::GetAllShapes() {
+std::array<std::vector<SymbolData::Shape>, SymbolId::NUM_SYMBOLS> SymbolData::GetAllShapes() {
 
-	std::array<Shape, NUM_SYMBOLS> data;
-	data[BigSquare] = Shape{ {-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0} };
+	std::array<std::vector<Shape>, NUM_SYMBOLS> data;
+	data[BigSquare] = { Shape{ {-1.0, -1.0}, {-1.0, 1.0}, {1.0, 1.0}, {1.0, -1.0} } };
 
 	AddArrows(data);
 
 	return data;
 }
 
-void SymbolData::AddArrows(std::array<Shape, SymbolId::NUM_SYMBOLS>& data)
+void SymbolData::AddArrows(std::array<std::vector<Shape>, SymbolId::NUM_SYMBOLS>& data)
 {
 	// Sigma's arrows
 	Shape arrow1 = {
@@ -157,32 +164,32 @@ void SymbolData::AddArrows(std::array<Shape, SymbolId::NUM_SYMBOLS>& data)
 	arrow2 = Scale(arrow2, scale);
 	arrow3 = Scale(arrow3, scale);
 
-	data[Arrow1E] = RotateClockwise(arrow1, 0);
-	data[Arrow1SE] = RotateClockwise(arrow1, 45);
-	data[Arrow1S] = RotateClockwise(arrow1, 90);
-	data[Arrow1SW] = RotateClockwise(arrow1, 135);
-	data[Arrow1W] = RotateClockwise(arrow1, 180);
-	data[Arrow1NW] = RotateClockwise(arrow1, 225);
-	data[Arrow1N] = RotateClockwise(arrow1, 270);
-	data[Arrow1NE] = RotateClockwise(arrow1, 315);
+	data[Arrow1E] = {RotateClockwise(arrow1, 0)};
+	data[Arrow1SE] = {RotateClockwise(arrow1, 45)};
+	data[Arrow1S] = {RotateClockwise(arrow1, 90)};
+	data[Arrow1SW] = {RotateClockwise(arrow1, 135)};
+	data[Arrow1W] = {RotateClockwise(arrow1, 180)};
+	data[Arrow1NW] = {RotateClockwise(arrow1, 225)};
+	data[Arrow1N] = {RotateClockwise(arrow1, 270)};
+	data[Arrow1NE] = {RotateClockwise(arrow1, 315)};
 
-	data[Arrow2E] = RotateClockwise(arrow2, 0);
-	data[Arrow2SE] = Translate(RotateClockwise(arrow2, 45), translate / 2, translate / 2);
-	data[Arrow2S] = RotateClockwise(arrow2, 90);
-	data[Arrow2SW] = Translate(RotateClockwise(arrow2, 135), -translate / 2, translate / 2);
-	data[Arrow2W] = RotateClockwise(arrow2, 180);
-	data[Arrow2NW] = Translate(RotateClockwise(arrow2, 225), -translate / 2, -translate / 2);
-	data[Arrow2N] = RotateClockwise(arrow2, 270);
-	data[Arrow2NE] = Translate(RotateClockwise(arrow2, 315), translate / 2, -translate / 2);
+	data[Arrow2E] = {RotateClockwise(arrow2, 0)};
+	data[Arrow2SE] = {Translate(RotateClockwise(arrow2, 45), translate / 2, translate / 2)};
+	data[Arrow2S] = {RotateClockwise(arrow2, 90)};
+	data[Arrow2SW] = {Translate(RotateClockwise(arrow2, 135), -translate / 2, translate / 2)};
+	data[Arrow2W] = {RotateClockwise(arrow2, 180)};
+	data[Arrow2NW] = {Translate(RotateClockwise(arrow2, 225), -translate / 2, -translate / 2)};
+	data[Arrow2N] = {RotateClockwise(arrow2, 270)};
+	data[Arrow2NE] = {Translate(RotateClockwise(arrow2, 315), translate / 2, -translate / 2)};
 
 	
-	data[Arrow3E] = RotateClockwise(arrow3, 0);
-	data[Arrow3SE] = Translate(RotateClockwise(arrow3, 45), translate, translate);
-	data[Arrow3S] = RotateClockwise(arrow3, 90);
-	data[Arrow3SW] = Translate(RotateClockwise(arrow3, 135), -translate, translate);
-	data[Arrow3W] = RotateClockwise(arrow3, 180);
-	data[Arrow3NW] = Translate(RotateClockwise(arrow3, 225), -translate, -translate);
-	data[Arrow3N] = RotateClockwise(arrow3, 270);
-	data[Arrow3NE] = Translate(RotateClockwise(arrow3, 315), translate, -translate);
+	data[Arrow3E] = {RotateClockwise(arrow3, 0)};
+	data[Arrow3SE] = {Translate(RotateClockwise(arrow3, 45), translate, translate)};
+	data[Arrow3S] = {RotateClockwise(arrow3, 90)};
+	data[Arrow3SW] = {Translate(RotateClockwise(arrow3, 135), -translate, translate)};
+	data[Arrow3W] = {RotateClockwise(arrow3, 180)};
+	data[Arrow3NW] = {Translate(RotateClockwise(arrow3, 225), -translate, -translate)};
+	data[Arrow3N] = {RotateClockwise(arrow3, 270)};
+	data[Arrow3NE] = {Translate(RotateClockwise(arrow3, 315), translate, -translate)};
 }
 

--- a/Source/SymbolData.h
+++ b/Source/SymbolData.h
@@ -51,7 +51,7 @@ private:
 	static Shape RotateClockwise(const Shape& shape, int degrees);
 	static Shape Scale(const Shape& shape, double scale);
 	static Shape Translate(const Shape& shape, double dx, double dy);
-	static std::array<Shape, SymbolId::NUM_SYMBOLS> GetAllShapes();
+	static std::array<std::vector<Shape>, SymbolId::NUM_SYMBOLS> GetAllShapes();
 
-	static void AddArrows(std::array<Shape, SymbolId::NUM_SYMBOLS>& data);
+	static void AddArrows(std::array<std::vector<Shape>, SymbolId::NUM_SYMBOLS > & data);
 };


### PR DESCRIPTION
This is done by nesting the shape in a vector.

Symbols need to be declared as vectors of shape now. 

<img width="504" height="432" alt="image" src="https://github.com/user-attachments/assets/3b1d9d06-b33e-48d9-9b97-bf32649d4cda" />
