### PR TITLE
Added option for legacy pillars

### DIFF
--- a/App/Main.cpp
+++ b/App/Main.cpp
@@ -34,6 +34,7 @@
 #define IDC_DIFFICULTY_EXPERT 0x502
 #define IDC_COLORBLIND 0x503
 #define IDC_DOUBLE 0x504
+#define IDC_LEGACYPILLAR 0x505
 
 #define SHAPE_11 0x1000
 #define SHAPE_12 0x2000
@@ -57,7 +58,7 @@
 //Panel to edit
 PanelID panelID = TUT_DOT_1;
 
-HWND hwndSeed, hwndRandomize, hwndW, hwndH, hwndCol, hwndRow, hwndElem, hwndVariant, hwndColor, hwndLoadingText, hwndNormal, hwndExpert, hwndColorblind, hwndDoubleMode;
+HWND hwndSeed, hwndRandomize, hwndW, hwndH, hwndCol, hwndRow, hwndElem, hwndVariant, hwndColor, hwndLoadingText, hwndNormal, hwndExpert, hwndColorblind, hwndDoubleMode, hwndLegacyPillars;
 Panel panel;
 Randomizer randomizer;
 Generate generator;
@@ -146,6 +147,11 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		case IDC_DOUBLE:
 			randomizer.doubleMode = !IsDlgButtonChecked(hwnd, IDC_DOUBLE);
 			CheckDlgButton(hwnd, IDC_DOUBLE, randomizer.doubleMode);
+			break;
+		case IDC_LEGACYPILLAR:
+			memory->legacyPillar = !IsDlgButtonChecked(hwnd, IDC_LEGACYPILLAR);
+			CheckDlgButton(hwnd, IDC_LEGACYPILLAR, memory->legacyPillar);
+			memory->setPillar();
 			break;
 
 		//Randomize button
@@ -470,19 +476,22 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
 	hwndDoubleMode = CreateWindow(L"BUTTON", L"Double Mode - In addition to generating new puzzles, the randomizer will also shuffle the location of most puzzles. (Not recommended for first playthrough)",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_CHECKBOX | BS_MULTILINE,
 		10, 200, 570, 35, hwnd, (HMENU)IDC_DOUBLE, hInstance, NULL);
+	hwndLegacyPillars = CreateWindow(L"BUTTON", L"Legacy Pillars - Pillars will now behave like they did in the legacy version making them much nicer to solve.",
+		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_CHECKBOX | BS_MULTILINE,
+		10, 240, 570, 50, hwnd, (HMENU)IDC_LEGACYPILLAR, hInstance, NULL);
 	if (randomizer.doubleMode) SendMessage(hwndDoubleMode, BM_SETCHECK, BST_CHECKED, 1);
 
 	CreateWindow(L"STATIC", L"Enter a seed (optional):",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | SS_LEFT,
-		10, 250, 160, 16, hwnd, NULL, hInstance, NULL);
+		10, 300, 160, 16, hwnd, NULL, hInstance, NULL);
 	hwndSeed = CreateWindow(MSFTEDIT_CLASS, lastSeed == 0 ? L"" : std::to_wstring(lastSeed).c_str(),
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | WS_BORDER,
-		180, 245, 60, 26, hwnd, NULL, hInstance, NULL);
+		180, 295, 60, 26, hwnd, NULL, hInstance, NULL);
 	SendMessage(hwndSeed, EM_SETEVENTMASK, NULL, ENM_CHANGE); // Notify on text change
 
 	hwndRandomize = CreateWindow(L"BUTTON", L"Randomize",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
-		250, 245, 130, 26, hwnd, (HMENU)IDC_RANDOMIZE, hInstance, NULL);
+		250, 295, 130, 26, hwnd, (HMENU)IDC_RANDOMIZE, hInstance, NULL);
 
 	hwndLoadingText = CreateWindow(L"STATIC", L"",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | SS_LEFT,

--- a/App/Main.cpp
+++ b/App/Main.cpp
@@ -478,24 +478,24 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
 		10, 200, 570, 35, hwnd, (HMENU)IDC_DOUBLE, hInstance, NULL);
 	hwndLegacyPillars = CreateWindow(L"BUTTON", L"Legacy Pillars - Pillars will now behave like they did in the legacy version making them much nicer to solve.",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_CHECKBOX | BS_MULTILINE,
-		10, 240, 570, 50, hwnd, (HMENU)IDC_LEGACYPILLAR, hInstance, NULL);
+		10, 240, 570, 35, hwnd, (HMENU)IDC_LEGACYPILLAR, hInstance, NULL);
 	if (randomizer.doubleMode) SendMessage(hwndDoubleMode, BM_SETCHECK, BST_CHECKED, 1);
 
 	CreateWindow(L"STATIC", L"Enter a seed (optional):",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | SS_LEFT,
-		10, 300, 160, 16, hwnd, NULL, hInstance, NULL);
+		10, 290, 160, 16, hwnd, NULL, hInstance, NULL);
 	hwndSeed = CreateWindow(MSFTEDIT_CLASS, lastSeed == 0 ? L"" : std::to_wstring(lastSeed).c_str(),
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | WS_BORDER,
-		180, 295, 60, 26, hwnd, NULL, hInstance, NULL);
+		180, 285, 60, 26, hwnd, NULL, hInstance, NULL);
 	SendMessage(hwndSeed, EM_SETEVENTMASK, NULL, ENM_CHANGE); // Notify on text change
 
 	hwndRandomize = CreateWindow(L"BUTTON", L"Randomize",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
-		250, 295, 130, 26, hwnd, (HMENU)IDC_RANDOMIZE, hInstance, NULL);
+		250, 285, 130, 26, hwnd, (HMENU)IDC_RANDOMIZE, hInstance, NULL);
 
 	hwndLoadingText = CreateWindow(L"STATIC", L"",
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | SS_LEFT,
-		400, 250, 160, 16, hwnd, NULL, hInstance, NULL);
+		400, 290, 160, 16, hwnd, NULL, hInstance, NULL);
 
 	std::ifstream configFile("WRPGconfig.txt");
 	if (configFile.is_open()) {

--- a/Source/Memory.cpp
+++ b/Source/Memory.cpp
@@ -103,6 +103,7 @@ void Memory::create()
 		_singleton->fixTriangleNegation();
 		_singleton->setupCustomSymbols();
 		_singleton->findActivePanel();
+		_singleton->findPillarLegacyChange();
 	}
 }
 
@@ -123,12 +124,32 @@ void Memory::findActivePanel() {
 	});
 }
 
+void Memory::findPillarLegacyChange() {
+	ScanForBytes({ 0x0F, 0x2F, 0xE3, 0x73, 0x08, 0xF3, 0x0F, 0x59, 0x15}, [this](__int64 offset, int index, const std::vector<byte>& data) {
+		_pillarLegacyChange = offset + index + 3;
+		return true;
+		});
+}
+
 PanelID Memory::GetActivePanel() {
 	return static_cast<PanelID>(_singleton->ReadData<PanelID>(_activePanelOffsets, 1)[0] - 1);
 }
 
 void Memory::invalidateCache() {
 	_computedAddresses = std::map<uintptr_t, uintptr_t>();
+}
+
+void Memory::setPillar() {
+	Memory* memory = Memory::get();
+	if (legacyPillar) {
+		memory->WriteData<byte>({ (int)(_pillarLegacyChange) }, { 0x90, 0x90 });
+		memory->WriteData<byte>({ (int)(_pillarLegacyChange + 10) }, { 0x90, 0x90, 0x90, 0x90, 0x90 });
+	}
+	else {
+		memory->WriteData<byte>({ (int)(_pillarLegacyChange) }, { 0x73, 0x08 });
+		memory->WriteData<byte>({ (int)(_pillarLegacyChange +10) }, { 0xF3, 0x41, 0x0F, 0x59, 0xD4 });
+	}
+
 }
 
 void Memory::findGlobals() {

--- a/Source/Memory.cpp
+++ b/Source/Memory.cpp
@@ -147,7 +147,7 @@ void Memory::setPillar() {
 	}
 	else {
 		memory->WriteData<byte>({ (int)(_pillarLegacyChange) }, { 0x73, 0x08 });
-		memory->WriteData<byte>({ (int)(_pillarLegacyChange +10) }, { 0xF3, 0x41, 0x0F, 0x59, 0xD4 });
+		memory->WriteData<byte>({ (int)(_pillarLegacyChange + 10) }, { 0xF3, 0x41, 0x0F, 0x59, 0xD4 });
 	}
 
 }

--- a/Source/Memory.h
+++ b/Source/Memory.h
@@ -54,6 +54,8 @@ public:
 	static void create();
 	static Memory* get();
 	void invalidateCache();
+	void setPillar ();
+	bool legacyPillar = false;
 
 	Memory(const Memory& memory) = delete;
 	Memory& operator=(const Memory& other) = delete;
@@ -144,6 +146,7 @@ public:
 	static __int64 ReadStaticInt(__int64 offset, int index, const std::vector<byte>& data, size_t bytesToEOL = 4);
 
 	int GLOBALS = 0;
+
 	bool showMsg = false;
 	int globalsTests[3] = {
 		0x62D0A0, //Steam and Epic Games
@@ -157,6 +160,7 @@ public:
 		void fixTriangleNegation();
 		void setupCustomSymbols();
 		void findActivePanel();
+		void findPillarLegacyChange();
 
 		template<class T>
 		std::vector<T> ReadData(const std::vector<int>& offsets, size_t numItems) {
@@ -206,6 +210,7 @@ public:
 		std::map<uintptr_t, uintptr_t> _computedAddresses;
 		std::vector<int> _activePanelOffsets;
 		std::map<std::pair<int, int>, int> _arraySizes;
+		uint64_t _pillarLegacyChange;
 		uintptr_t _baseAddress = 0;
 		HANDLE _handle = nullptr;
 


### PR DESCRIPTION
This adds an option to the randomizer to make pillars behave like they did in older version. This is done by removing two assembly instruction in the cylinder camera code